### PR TITLE
WIP - Converting CoAxialRotor to MultiRotor class

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -425,7 +425,7 @@ class BearingElement(Element):
         for k, v in coefficients.items():
             setattr(self, k, v)
 
-        self.n = n
+        self._n = n
         self.n_link = n_link
         self.n_l = n
         self.n_r = n

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -52,7 +52,7 @@ class DiskElement(Element):
 
     @check_units
     def __init__(self, n, m, Id, Ip, tag=None, scale_factor=1.0, color="Firebrick"):
-        self.n = int(n)
+        self._n = int(n)
         self.n_l = n
         self.n_r = n
 

--- a/ross/element.py
+++ b/ross/element.py
@@ -15,8 +15,47 @@ class Element(ABC):
     """
 
     def __init__(self, n, tag=None):
-        self.n = n
+        self._n = n
         self.tag = tag
+
+    @property
+    def n(self):
+        """Set the element number as property.
+
+        Returns
+        -------
+        n : int
+            Element number
+        """
+        return self._n
+
+    @n.setter
+    def n(self, value):
+        """Set a new value for the element number.
+
+        Parameters
+        ----------
+        value : int
+            element number
+
+        Example
+        -------
+        >>> from ross.materials import steel
+        >>> shaft1 = ShaftElement(
+        ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
+        ...        material=steel, rotary_inertia=True, shear_effects=True
+        ... )
+        >>> shaft1.n = 0
+        >>> shaft1 # doctest: +ELLIPSIS
+        ShaftElement(L=0.25, idl=0.0...
+        """
+        self._n = value
+        self.n_l = value
+        if value is not None:
+            if hasattr(self, "L"):
+                self.n_r = value + 1
+            else:
+                self.n_r = value
 
     def save(self, file):
         """Save the element in a .toml file.
@@ -195,7 +234,7 @@ class Element(ABC):
         >>> from ross.disk_element import disk_example
         >>> disk = disk_example()
         >>> disk.summary() # doctest: +ELLIPSIS
-        n                             0
+        _n                            0
         n_l                           0
         n_r                           0...
         """

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -53,8 +53,10 @@ class PointMass(Element):
 
     @check_units
     def __init__(self, n=None, m=None, mx=None, my=None, tag=None, color="DarkSalmon"):
-        self.n = n
+        self._n = n
         self.m = m
+        self.n_l = n
+        self.n_r = n
 
         if mx is None and my is None:
             mx = float(m)

--- a/ross/results.py
+++ b/ross/results.py
@@ -3334,8 +3334,8 @@ class SummaryResults(Results):
         disk_data = {
             "Tag": self.df_disks["tag"],
             "Shaft number": self.df_disks["shaft_number"],
-            "Node": self.df_disks["n"],
-            "Nodal Position": self.nodes_pos[self.df_bearings["n"]],
+            "Node": self.df_disks["_n"],
+            "Nodal Position": self.nodes_pos[self.df_bearings["_n"]],
             "Mass": self.df_disks["m"].map("{:.3f}".format),
             "Ip": self.df_disks["Ip"].map("{:.3e}".format),
         }
@@ -3343,9 +3343,9 @@ class SummaryResults(Results):
         bearing_data = {
             "Tag": self.df_bearings["tag"],
             "Shaft number": self.df_bearings["shaft_number"],
-            "Node": self.df_bearings["n"],
+            "Node": self.df_bearings["_n"],
             "N_link": self.df_bearings["n_link"],
-            "Nodal Position": self.nodes_pos[self.df_bearings["n"]],
+            "Nodal Position": self.nodes_pos[self.df_bearings["_n"]],
             "Bearing force": list(self.brg_forces.values()),
         }
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3418,7 +3418,7 @@ class CoAxialRotor(Rotor):
 
         # check consistence for disks and bearings location
         if len(df_point_mass) > 0:
-            max_loc_point_mass = df_point_mass.n.max()
+            max_loc_point_mass = df_point_mass._n.max()
         else:
             max_loc_point_mass = 0
         max_location = max(df_shaft.n_r.max(), max_loc_point_mass)
@@ -3612,7 +3612,7 @@ class CoAxialRotor(Rotor):
         for z_pos in dfb["nodes_pos_l"]:
             dfb_z_pos = dfb[dfb.nodes_pos_l == z_pos]
             dfb_z_pos = dfb_z_pos.sort_values(by="n_l")
-            for n, t, nlink in zip(dfb_z_pos.n, dfb_z_pos.tag, dfb_z_pos.n_link):
+            for n, t, nlink in zip(dfb_z_pos._n, dfb_z_pos.tag, dfb_z_pos.n_link):
                 if n in self.nodes:
                     if z_pos == df_shaft["nodes_pos_l"].iloc[0]:
                         y_pos = (np.max(df_shaft["odl"][df_shaft.n_l == n].values)) / 2

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -287,7 +287,7 @@ class Rotor(object):
 
         # check consistence for disks and bearings location
         if len(df_point_mass) > 0:
-            max_loc_point_mass = df_point_mass.n.max()
+            max_loc_point_mass = df_point_mass._n.max()
         else:
             max_loc_point_mass = 0
         max_location = max(df_shaft.n_r.max(), max_loc_point_mass)
@@ -408,11 +408,20 @@ class Rotor(object):
             if bearings_no_zloc:
                 if b in bearings_no_zloc:
                     # first check if b.n is on list, if not, check for n_link
-                    node_l = df.loc[(df.n_l == b.n) & (df.tag != b.tag), "nodes_pos_l"]
-                    node_r = df.loc[(df.n_r == b.n) & (df.tag != b.tag), "nodes_pos_r"]
+                    node_l = df.loc[
+                        (df.n_l == b.n) & (df.tag != b.tag) & (df.type != "PointMass"),
+                        "nodes_pos_l",
+                    ]
+                    node_r = df.loc[
+                        (df.n_r == b.n) & (df.tag != b.tag) & (df.type != "PointMass"),
+                        "nodes_pos_r",
+                    ]
                     if len(node_l) == 0 and len(node_r) == 0:
                         node_l = df.loc[
-                            (df.n_link == b.n) & (df.tag != b.tag), "nodes_pos_l"
+                            (df.n_link == b.n)
+                            & (df.tag != b.tag)
+                            & (df.type != "PointMass"),
+                            "nodes_pos_l",
                         ]
                         node_r = node_l
                     if len(node_l):
@@ -433,6 +442,7 @@ class Rotor(object):
             )
         ]
         dfb = df[df.type.isin(classes)]
+
         z_positions = [pos for pos in dfb["nodes_pos_l"]]
         z_positions = list(dict.fromkeys(z_positions))
         for z_pos in z_positions:
@@ -2822,16 +2832,16 @@ class Rotor(object):
                 & (aux_rotor.df["shaft_number"] == i)
             ]
             for j, row in aux_df.iterrows():
-                if row["n"] == n_max:
+                if row["_n"] == n_max:
                     force = -np.round(elm_forces_y[-1, 1], 1)
                 else:
-                    force = np.round(elm_forces_y[int(row["n"]) - n_min, 0], 1)
+                    force = np.round(elm_forces_y[int(row["_n"]) - n_min, 0], 1)
 
                 if row["type"] == "DiskElement":
-                    DskForce_nodal["node_" + str(int(row["n"]))] = force
+                    DskForce_nodal["node_" + str(int(row["_n"]))] = force
                     DskForce_tag[row["tag"]] = force
                 elif row["type"] == "BearingElement":
-                    BrgForce_nodal["node_" + str(int(row["n"]))] = force
+                    BrgForce_nodal["node_" + str(int(row["_n"]))] = force
                     BrgForce_tag[row["tag"]] = force
                     if not pd.isna(row["n_link"]):
                         BrgForce_nodal["node_" + str(int(row["n_link"]))] = -force

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3389,12 +3389,12 @@ class CoAxialRotor(Rotor):
                     nodes_pos_r[k + i] = nodes_pos_l[k + i] + df_shaft.loc[k + i, "L"]
 
                 if sh.n in df_bearings["n_link"].values:
-                    idx = df_bearings.loc[df_bearings.n_link == sh.n, "n"].values[0]
+                    idx = df_bearings.loc[df_bearings.n_link == sh.n, "_n"].values[0]
                     nodes_pos_l[i : sh.n] += nodes_pos_l[idx] - nodes_pos_l[k + i]
                     nodes_pos_r[i : sh.n] += nodes_pos_r[idx] - nodes_pos_r[k + i]
                     axial_cg_pos[i : sh.n] += nodes_pos_r[idx] - nodes_pos_r[k + i]
                 elif sh.n_r in df_bearings["n_link"].values:
-                    idx = df_bearings.loc[df_bearings.n_link == sh.n_r, "n"].values[0]
+                    idx = df_bearings.loc[df_bearings.n_link == sh.n_r, "_n"].values[0]
                     nodes_pos_l[i : sh.n_r] += nodes_pos_l[idx - 1] - nodes_pos_l[k + i]
                     nodes_pos_r[i : sh.n_r] += nodes_pos_r[idx - 1] - nodes_pos_r[k + i]
                     axial_cg_pos[i : sh.n_r] += (
@@ -3527,7 +3527,7 @@ class CoAxialRotor(Rotor):
 
         if "n_link" in df.columns and df_point_mass.index.size > 0:
             aux_link = list(df["n_link"].dropna().unique().astype(int))
-            aux_node = list(df_point_mass["n"].dropna().unique().astype(int))
+            aux_node = list(df_point_mass["_n"].dropna().unique().astype(int))
             self.link_nodes = list(set(aux_link) & set(aux_node))
         else:
             self.link_nodes = []

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -426,42 +426,6 @@ class ShaftElement(Element):
         data["material"] = Material(**data["material"])
         return cls(**data)
 
-    # @property
-    # def n(self):
-    #     """Set the element number as property.
-
-    #     Returns
-    #     -------
-    #     n : int
-    #         Element number
-    #     """
-    #     return self._n
-
-    # @n.setter
-    # def n(self, value):
-    #     """Set a new value for the element number.
-
-    #     Parameters
-    #     ----------
-    #     value : int
-    #         element number
-
-    #     Example
-    #     -------
-    #     >>> from ross.materials import steel
-    #     >>> shaft1 = ShaftElement(
-    #     ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
-    #     ...        material=steel, rotary_inertia=True, shear_effects=True
-    #     ... )
-    #     >>> shaft1.n = 0
-    #     >>> shaft1 # doctest: +ELLIPSIS
-    #     ShaftElement(L=0.25, idl=0.0...
-    #     """
-    #     self._n = value
-    #     self.n_l = value
-    #     if value is not None:
-    #         self.n_r = value + 1
-
     def dof_mapping(self):
         """Degrees of freedom mapping.
 

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -426,41 +426,41 @@ class ShaftElement(Element):
         data["material"] = Material(**data["material"])
         return cls(**data)
 
-    @property
-    def n(self):
-        """Set the element number as property.
+    # @property
+    # def n(self):
+    #     """Set the element number as property.
 
-        Returns
-        -------
-        n : int
-            Element number
-        """
-        return self._n
+    #     Returns
+    #     -------
+    #     n : int
+    #         Element number
+    #     """
+    #     return self._n
 
-    @n.setter
-    def n(self, value):
-        """Set a new value for the element number.
+    # @n.setter
+    # def n(self, value):
+    #     """Set a new value for the element number.
 
-        Parameters
-        ----------
-        value : int
-            element number
+    #     Parameters
+    #     ----------
+    #     value : int
+    #         element number
 
-        Example
-        -------
-        >>> from ross.materials import steel
-        >>> shaft1 = ShaftElement(
-        ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
-        ...        material=steel, rotary_inertia=True, shear_effects=True
-        ... )
-        >>> shaft1.n = 0
-        >>> shaft1 # doctest: +ELLIPSIS
-        ShaftElement(L=0.25, idl=0.0...
-        """
-        self._n = value
-        self.n_l = value
-        if value is not None:
-            self.n_r = value + 1
+    #     Example
+    #     -------
+    #     >>> from ross.materials import steel
+    #     >>> shaft1 = ShaftElement(
+    #     ...        L=0.25, idl=0, idr=0, odl=0.05, odr=0.08,
+    #     ...        material=steel, rotary_inertia=True, shear_effects=True
+    #     ... )
+    #     >>> shaft1.n = 0
+    #     >>> shaft1 # doctest: +ELLIPSIS
+    #     ShaftElement(L=0.25, idl=0.0...
+    #     """
+    #     self._n = value
+    #     self.n_l = value
+    #     if value is not None:
+    #         self.n_r = value + 1
 
     def dof_mapping(self):
         """Degrees of freedom mapping.


### PR DESCRIPTION
- Add "n" as property to Element Class
  - This feature allows us to manipulate the node value of any element even after building a rotor. It'll make the task of changing nodes easier in MultiRotor class.
  - Changes all references of "n" to "_n".

- More coming soon