### PR TITLE
Fix copying a bearing and setting node

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -163,8 +163,6 @@ class BearingElement(Element):
 
         self.n = n
         self.n_link = n_link
-        self.n_l = n
-        self.n_r = n
         self.tag = tag
         self.color = color
         self.scale_factor = scale_factor
@@ -1899,8 +1897,6 @@ class BearingElement6DoF(BearingElement):
             "cxy_interpolated",
             "cyx_interpolated",
             "czz_interpolated",
-            "n_l",
-            "n_r",
             "dof_global_index",
         ]
         for p in params_to_remove:

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -176,6 +176,9 @@ class Rotor(object):
                 disk.tag = "Disk " + str(i)
 
         for i, brg in enumerate(bearing_elements):
+            # add n_l and n_r to bearing elements
+            brg.n_l = brg.n
+            brg.n_r = brg.n
             if not isinstance(brg, SealElement) and brg.tag is None:
                 brg.tag = "Bearing " + str(i)
             elif isinstance(brg, SealElement) and brg.tag is None:
@@ -3141,8 +3144,8 @@ class Rotor(object):
             for Brg_SealEl in brg_seal_data:
                 aux_Brg_SealEl = deepcopy(Brg_SealEl)
                 aux_Brg_SealEl.n = nel_r * Brg_SealEl.n
-                aux_Brg_SealEl.n_l = nel_r * Brg_SealEl.n_l
-                aux_Brg_SealEl.n_r = nel_r * Brg_SealEl.n_r
+                aux_Brg_SealEl.n_l = nel_r * Brg_SealEl.n
+                aux_Brg_SealEl.n_r = nel_r * Brg_SealEl.n
                 bearing_elements.append(aux_Brg_SealEl)
 
             regions.append(disk_elements)
@@ -3304,6 +3307,8 @@ class CoAxialRotor(Rotor):
                 disk.tag = "Disk " + str(i)
 
         for i, brg in enumerate(bearing_elements):
+            brg.n_l = brg.n
+            brg.n_r = brg.n
             if brg.__class__.__name__ == "BearingElement" and brg.tag is None:
                 brg.tag = "Bearing " + str(i)
             if brg.__class__.__name__ == "SealElement" and brg.tag is None:


### PR DESCRIPTION
A common requirement is to run an expensive bearing calculation and then copy this bearing and just set a different node where it will be located in the rotor:

```python
import ross as rs
from copy import copy

bearing_de = rs.SpecialBearing(n=0, ...)
bearing_nde = copy(bearing_de)
bearing_nde.n = 20

```
The above code would give an error, since in the rotor assembly we have a code which relies on bearings having n_l and n_d attributes (although this only make senses to shaft elements).

This code removes the attribute from bearing initialization and sets it at rotor initialization. This way it is possible to modify the attribute before creating the rotor.