### PR TITLE
Fix ucs modal plots

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -4540,7 +4540,6 @@ class UCSResults(Results):
     def plot_mode_2d(
         self,
         critical_mode,
-        evec=None,
         fig=None,
         frequency_type="wd",
         title=None,
@@ -4554,8 +4553,6 @@ class UCSResults(Results):
         ----------
         critical_mode : int
             The n'th critical mode.
-        evec : array
-            Array containing the system eigenvectors
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         frequency_type : str, optional
@@ -4592,7 +4589,6 @@ class UCSResults(Results):
         idx = (np.abs(modal_critical.wd - forward_frequency)).argmin()
         fig = modal_critical.plot_mode_2d(
             idx,
-            evec=evec,
             fig=fig,
             frequency_type=frequency_type,
             title=title,
@@ -4606,7 +4602,6 @@ class UCSResults(Results):
     def plot_mode_3d(
         self,
         critical_mode,
-        evec=None,
         fig=None,
         frequency_type="wd",
         title=None,
@@ -4621,8 +4616,6 @@ class UCSResults(Results):
         critical_mode : int
             The n'th critical mode.
             Default is None
-        evec : array
-            Array containing the system eigenvectors
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         frequency_type : str, optional
@@ -4659,7 +4652,6 @@ class UCSResults(Results):
         idx = (np.abs(modal_critical.wd - forward_frequency)).argmin()
         fig = modal_critical.plot_mode_3d(
             idx,
-            evec=evec,
             fig=fig,
             frequency_type=frequency_type,
             title=title,
@@ -4667,6 +4659,8 @@ class UCSResults(Results):
             frequency_units=frequency_units,
             **kwargs,
         )
+
+        return fig
 
 
 class Level1Results(Results):


### PR DESCRIPTION
Modal ucs plots had the evec argument, which is not used anymore since we have create the Shape object.