### PR TITLE
Add campbell mode shape plot

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1354,6 +1354,8 @@ class CampbellResults(Results):
         Array with the Logarithmic decrement
     whirl_values : array
         Array with the whirl values (0, 0.5 or 1)
+    modal_results : dict
+        Dictionary with the modal results for each speed in the speed range.
 
     Returns
     -------
@@ -1361,12 +1363,15 @@ class CampbellResults(Results):
         The figure object with the plot.
     """
 
-    def __init__(self, speed_range, wd, log_dec, damping_ratio, whirl_values):
+    def __init__(
+        self, speed_range, wd, log_dec, damping_ratio, whirl_values, modal_results
+    ):
         self.speed_range = speed_range
         self.wd = wd
         self.log_dec = log_dec
         self.damping_ratio = damping_ratio
         self.whirl_values = whirl_values
+        self.modal_results = modal_results
 
     @check_units
     def plot(

--- a/ross/results.py
+++ b/ross/results.py
@@ -85,6 +85,12 @@ class Results(ABC):
             data = {}
 
         data[f"{self.__class__.__name__}"] = args
+
+        try:
+            del data["CampbellResults"]["modal_results"]
+        except KeyError:
+            pass
+
         with open(file, "w") as f:
             toml.dump(data, f, encoder=toml.TomlNumpyEncoder())
 
@@ -148,6 +154,8 @@ class Results(ABC):
 
         data = toml.load(file)
         data = list(data.values())[0]
+        if cls == CampbellResults:
+            data["modal_results"] = None
         for key, value in data.items():
             if key == "rotor":
                 aux_file = str(file)[:-5] + "_rotor" + str(file)[-5:]
@@ -1666,6 +1674,20 @@ class CampbellResults(Results):
             scatter.on_click(_plot_with_mode_shape_callback)
 
         return VBox([camp_fig, plot_mode_3d])
+
+    def save(self, file):
+        # TODO save modal results
+        warn(
+            "The CampbellResults.save method is not saving the attribute 'modal_results' for now."
+        )
+        super().save(file)
+
+    @classmethod
+    def load(cls, file):
+        warn(
+            "The CampbellResults.save method is not saving the attribute 'modal_results' for now."
+        )
+        return super().load(file)
 
 
 class FrequencyResponseResults(Results):

--- a/ross/results.py
+++ b/ross/results.py
@@ -19,7 +19,6 @@ from scipy import linalg as la
 from ross.plotly_theme import tableau_colors
 from ross.units import Q_, check_units
 from ross.utils import intersection
-from ipywidgets import VBox
 
 __all__ = [
     "Orbit",
@@ -1611,6 +1610,12 @@ class CampbellResults(Results):
         fig=None,
         **kwargs,
     ):
+
+        try:
+            from ipywidgets import VBox
+        except ImportError:
+            raise ImportError("Please install ipywidgets to use this feature.")
+
         def _plot_with_mode_shape_callback(trace, points, state):
             point_idx = points.point_inds
             if len(point_idx) > 0:

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2101,8 +2101,10 @@ class Rotor(object):
 
         results = np.zeros([len(speed_range), frequencies, 6])
 
+        modal_results = {}
         for i, w in enumerate(speed_range):
             modal = self.run_modal(speed=w, num_modes=2 * frequencies)
+            modal_results[w] = modal
 
             if frequency_type == "wd":
                 results[i, :, 0] = modal.wd[:frequencies]
@@ -2125,6 +2127,7 @@ class Rotor(object):
             log_dec=results[..., 1],
             damping_ratio=results[..., 2],
             whirl_values=results[..., 3],
+            modal_results=modal_results,
         )
 
         return results


### PR DESCRIPTION
This adds an interactive plot where the user can click a mode in the
Campbell diagram and the respective shape will be plotted in a 3d plot.

To implement this we used the 'on_click' event that is available in
plotly and is associated with each trace in the figure.

To make the plots appear in a reasonable time we had to use the
.batch_update() method, otherwise in each step of the for loop the
figure would be updated, making the rendering of the plot very slow.

For now this has only been tested in a jupyter notebook environment,
in the future we could check on how to implement this in a streamlit
app.