### PR TITLE
Fix website links incorrect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ section for questions and further information.
 
 To format our code we use [Black](https://black.readthedocs.io/en/stable/), which is the *"uncompromising Python
 code formatter"*. You can configure your development environment to use Black before a commit. More information on how
-to set this is given at [Black's documentation](https://black.readthedocs.io/en/stable/integrations/editors.html).
+to set this is given at [Black's documentation](https://black.readthedocs.io/en/stable/integrations/index.html).
 
 We also recommend using the [pre-commit](https://pre-commit.com/) tool so that black is automatically run when doing a commit.
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,7 +5,7 @@
 ## Install Python
 
 The first step is to install Python. Since ROSS requires several packages to be installed besides Python, such as
-numpy and scipy, we recommend installing [Anaconda](https://www.anaconda.com/distribution/) (version 3.7 or higher) which is a
+numpy and scipy, we recommend installing [Anaconda](https://docs.anaconda.com/free/anaconda/index.html) (version 3.7 or higher) which is a
 scientific Python distribution that aims to simplify package management and deployment. It contains Python and a large
 number of packages that are commonly used.
 Alternatively, you may refer to the [Python website](http://www.python.org/).


### PR DESCRIPTION
Some website links were incorrect and out of date, for example the Anaconda installation website:

https://ross.readthedocs.io/en/stable/getting_started/installation.html