### PR TITLE
Fix issued related to use of locals() in bearing_seal_element.py

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -157,7 +157,6 @@ class BearingElement(Element):
             "myx",
         ]
 
-
         if kyy is None:
             kyy = kxx
         if cyy is None:
@@ -169,13 +168,12 @@ class BearingElement(Element):
                 myy = 0
             else:
                 myy = mxx
-        
+
         if mxx is None:
             mxx = 0
 
-        # all args to coefficients.  output of locals() should be READ ONLY        
+        # all args to coefficients.  output of locals() should be READ ONLY
         args_dict = locals()
-
 
         # check coefficients len for consistency
         coefficients_len = []
@@ -1846,7 +1844,6 @@ class BearingElement6DoF(BearingElement):
 
         new_args = ["kzz", "czz", "mzz"]
 
-
         coefficients = {}
 
         if kzz is None:
@@ -1861,7 +1858,7 @@ class BearingElement6DoF(BearingElement):
             else:
                 mzz = mxx * 0.0
 
-        #output of locals() should be READ ONLY
+        # output of locals() should be READ ONLY
         args_dict = locals()
 
         # check coefficients len for consistency

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -157,20 +157,22 @@ class BearingElement(Element):
             "myx",
         ]
 
-        # all args to coefficients
-        args_dict = locals()
 
         if kyy is None:
-            args_dict["kyy"] = kxx
+            kyy = kxx
         if cyy is None:
-            args_dict["cyy"] = cxx
+            cyy = cxx
 
         if myy is None:
             if mxx is None:
-                args_dict["mxx"] = 0
-                args_dict["myy"] = 0
+                mxx = 0
+                myy = 0
             else:
-                args_dict["myy"] = mxx
+                myy = mxx
+
+        # all args to coefficients.  output of locals() should be READ ONLY        
+        args_dict = locals()
+
 
         # check coefficients len for consistency
         coefficients_len = []
@@ -1841,20 +1843,23 @@ class BearingElement6DoF(BearingElement):
 
         new_args = ["kzz", "czz", "mzz"]
 
-        args_dict = locals()
+
         coefficients = {}
 
         if kzz is None:
-            args_dict["kzz"] = kxx * 0.0
+            kzz = kxx * 0.0
         if czz is None:
-            args_dict["czz"] = cxx * 0.0
+            czz = cxx * 0.0
 
         if mzz is None:
             if mxx is None:
-                args_dict["mxx"] = 0
-                args_dict["mzz"] = 0
+                mxx = 0
+                mzz = 0
             else:
-                args_dict["mzz"] = mxx * 0.0
+                mzz = mxx * 0.0
+
+        #output of locals() should be READ ONLY
+        args_dict = locals()
 
         # check coefficients len for consistency
         coefficients_len = []

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -169,6 +169,9 @@ class BearingElement(Element):
                 myy = 0
             else:
                 myy = mxx
+        
+        if mxx is None:
+            mxx = 0
 
         # all args to coefficients.  output of locals() should be READ ONLY        
         args_dict = locals()


### PR DESCRIPTION
Hi new contributor here.  I'm trying to build some projects using your library.  I was trying to use the debugger inside Spyder to help me debug some of the code that I had written, when I noticed that I was getting errors inside BearingElement.  Interesting, this code ran perfectly outside of the debugger, but failed inside the debugger.  I tracked it down to the use of locals() in BearingElement to create a dictionary, which was later modified.  The python documentation (https://docs.python.org/3/library/functions.html#locals) explicitly says that the dictionary returned by locals() should not be modified.  In this case it appeared to lead to implementation dependent behavior. Working normally, but not inside the debugger.  I've rewritten the code such that the dictionary is read only.

While doing this, I also noticed that there is a possible bug if some combinations of optional arguments are specified but others are not.  I've fixed that.

I hope this is helpful.  

For what its worth, here is the error that I was getting when running the original code inside the debugger.  The root cause of the issue is that the line args_dict["mxx"] = 0 may or may not actually update the value of mxx.  Its implementation dependent.  Outside the debugger, it works, but inside the debugger it doesn't.  

Traceback (most recent call last):

  File /usr/lib/python3/dist-packages/spyder_kernels/py3compat.py:356 in compat_exec
    exec(code, globals, locals)

  File test3.py:33
    rotor = rotor_example1()

 File test3.py:28 in rotor_example1
    bearing1 = rs.BearingElement(1, kxx=k, kyy=k, cxx=c, cyy=c)

  File ross/ross/units.py:193 in inner
    return func(*base_unit_args, **base_unit_kwargs)

  File ross/ross/bearing_seal_element.py:181 in __init__
    coefficient, interpolated = self._process_coefficient(args_dict[arg])

  File ross/ross/bearing_seal_element.py:218 in _process_coefficient
    if len(coefficient) > 1:

TypeError: object of type 'NoneType' has no len()