### PR TITLE
Fix use of Kst matrix

### DIFF
--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -638,6 +638,42 @@ class DiskElement6DoF(DiskElement):
         # fmt: on
         return K
 
+    def Kdt(self):
+        """Dynamic stiffness matrix for an instance of a 6 DoF disk
+        element.
+
+        Stiffness matrix for the 6 DoF disk element associated with the
+        transient motion. It needs to be multiplied by the angular
+        acceleration when considered in time dependent analyses.
+
+        Returns
+        -------
+        Kdt : np.ndarray
+            A matrix of floats containing the values of the dynamic
+            stiffness matrix.
+
+        Examples
+        --------
+        >>> disk = disk_example_6dof()
+        >>> disk.Kdt().round(2)
+        array([[0.  , 0.  , 0.  , 0.  , 0.  , 0.  ],
+               [0.  , 0.  , 0.  , 0.  , 0.  , 0.  ],
+               [0.  , 0.  , 0.  , 0.  , 0.  , 0.  ],
+               [0.  , 0.  , 0.  , 0.  , 0.  , 0.  ],
+               [0.  , 0.  , 0.  , 0.33, 0.  , 0.  ],
+               [0.  , 0.  , 0.  , 0.  , 0.  , 0.  ]])
+        """
+        Ip = self.Ip
+        # fmt: off
+        Kdt = np.array([[0, 0, 0,  0, 0, 0],
+                        [0, 0, 0,  0, 0, 0],
+                        [0, 0, 0,  0, 0, 0],
+                        [0, 0, 0,  0, 0, 0],
+                        [0, 0, 0, Ip, 0, 0],
+                        [0, 0, 0,  0, 0, 0]])
+        # fmt: on
+        return Kdt
+
     def C(self):
         """Damping matrix for an instance of a 6 DoF disk element.
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -955,12 +955,15 @@ class Rotor(object):
     def Kst(self):
         """Dynamic stiffness matrix for an instance of a rotor.
 
+        Stiffness matrix associated with the transient motion of the
+        shaft. It needs to be multiplied by the angular acceleration
+        when considered in time dependent analyses.
+
         Returns
         -------
         Kst0 : np.ndarray
-            Dynamic stiffness matrix for the rotor.
-            This matris IS OMEGA dependent
-            Only useable to the 6 DoF model.
+            Dynamic stiffness matrix for the rotor. Only useable to
+            the 6 DoF model in variable speed analyses.
 
         Examples
         --------
@@ -1080,7 +1083,7 @@ class Rotor(object):
         # fmt: off
         A = np.vstack(
             [np.hstack([Z, I]),
-             np.hstack([la.solve(-self.M(frequency), self.K(frequency) + self.Kst()*speed), la.solve(-self.M(frequency), (self.C(frequency) + self.G() * speed))])])
+             np.hstack([la.solve(-self.M(frequency), self.K(frequency)), la.solve(-self.M(frequency), (self.C(frequency) + self.G() * speed))])])
         # fmt: on
 
         return A

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -1716,7 +1716,7 @@ class ShaftElement6DoF(ShaftElement):
         Returns
         -------
         K : np.ndarray
-            Omega independent stiffness matrix for the 6 DoF shaft element.
+            Stiffness matrix for the 6 DoF shaft element.
 
         Examples
         --------
@@ -1826,15 +1826,9 @@ class ShaftElement6DoF(ShaftElement):
     def Kst(self):
         """Dynamic stiffness matrix for an instance of a 6 DoF shaft element.
 
-        Dynamic stiffness matrix for the 6 DoF shaft element. This is
-        directly dependent on the rotation speed Omega. It needs to be
-        multiplied by the adequate Omega value when used in time depen-
-        dent analyses. The matrix multiplier term is:
-
-        [(Iz*Omega*rho)/(15*L)] * [Kst]
-
-        and here the Omega value has been suppressed and must be added
-        in the adequate analyses.
+        Stiffness matrix for the 6 DoF shaft element associated with
+        the transient motion. It needs to be multiplied by the angular
+        acceleration when considered in time dependent analyses.
 
         Returns
         -------
@@ -1903,10 +1897,9 @@ class ShaftElement6DoF(ShaftElement):
     def G(self):
         """Gyroscopic matrix for an instance of a 6 DoFs shaft element.
 
-        Gyroscopic matrix for the 6 DoF shaft element. Similar to the Kst
-        stiffness matrix, this Gyro matrix is also multiplied by the value
-        of the rotating speed Omega. It is omitted from this and must be
-        added in the respective analyses.
+        Gyroscopic matrix for the 6 DoF shaft element. It needs to be
+        multiplied by the angular velocity when considered in time
+        dependent analyses.
 
         Returns
         -------


### PR DESCRIPTION
This PR resolve issue #1022 .

The Kdt matrix was also created for the disk element. However, this matrix is applied in time-dependent analyzes when there is speed variation. As the Kst matrix, it must be multiplied by the angular acceleration.