### PR TITLE
Improve Campbell diagram for 6 dof model

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1435,7 +1435,7 @@ class CampbellResults(Results):
     def plot(
         self,
         harmonics=[1],
-        frequency_units="rpm",
+        frequency_units="RPM",
         damping_parameter="log_dec",
         frequency_range=None,
         damping_range=None,
@@ -1451,7 +1451,7 @@ class CampbellResults(Results):
             The default is to plot 1x.
         frequency_units : str, optional
             Frequency units.
-            Default is "rpm"
+            Default is "RPM".
         damping_parameter : str, optional
             Define which value to show for damping. We can use "log_dec" or "damping_ratio".
             Default is "log_dec".
@@ -1558,7 +1558,7 @@ class CampbellResults(Results):
                     legendgroup="Crit. Speed",
                     showlegend=True,
                     hovertemplate=(
-                        f"Frequency ({frequency_units}): %{{x:.2f}}<br>Critical Speed ({frequency_units}): %{{y:.2f}}"
+                        f"Frequency ({frequency_units}): %{{y:.2f}}<br>Critical Speed ({frequency_units}): %{{x:.2f}}"
                     ),
                 )
             )
@@ -1650,7 +1650,7 @@ class CampbellResults(Results):
             )
 
         fig.update_xaxes(
-            title_text=f"Frequency ({frequency_units})",
+            title_text=f"Rotor Speed ({frequency_units})",
             range=[
                 np.min(Q_(speed_range, "rad/s").to(frequency_units).m),
                 np.max(Q_(speed_range, "rad/s").to(frequency_units).m),

--- a/ross/results.py
+++ b/ross/results.py
@@ -1742,7 +1742,8 @@ class CampbellResults(Results):
 
         crit_speeds = camp_fig.data[0]["x"]
         for w in crit_speeds:
-            modal_results_crit[w] = self.run_modal(Q_(w, frequency_units).to("rad/s").m)
+            w_si = Q_(w, frequency_units).to("rad/s").m
+            modal_results_crit[w_si] = self.run_modal(w_si)
 
         for scatter in camp_fig.data:
             scatter.on_click(_plot_with_mode_shape_callback)

--- a/ross/results.py
+++ b/ross/results.py
@@ -422,7 +422,7 @@ class Shape(Results):
         self._calculate()
 
     def _classify(self):
-        self.mode_id = "Lateral"
+        self.mode_type = "Lateral"
 
         if self.number_dof == 6:
             size = len(self.vector)
@@ -433,9 +433,9 @@ class Shape(Results):
             nonzero_dofs = np.nonzero(np.abs(self.vector).round(6))[0]
 
             if np.isin(nonzero_dofs, axial_dofs).all():
-                self.mode_id = "Axial"
+                self.mode_type = "Axial"
             elif np.isin(nonzero_dofs, torsional_dofs).all():
-                self.mode_id = "Torsional"
+                self.mode_type = "Torsional"
 
     def _calculate_orbits(self):
         orbits = []
@@ -1581,7 +1581,7 @@ class CampbellResults(Results):
                 damping_values_i = damping_values[:, i]
 
                 mode_shape = np.array(
-                    [self.modal_results[j].shapes[i].mode_id for j in speed_range]
+                    [self.modal_results[j].shapes[i].mode_type for j in speed_range]
                 )
                 mode_mask_g = np.array([mode in legends for mode in mode_shape])
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1374,7 +1374,7 @@ class Rotor(object):
                     evalues, evectors = las.eigs(
                         A,
                         k=num_modes,
-                        sigma=0,
+                        sigma=1,
                         ncv=2 * num_modes,
                         which="LM",
                         v0=self._v0,


### PR DESCRIPTION
Resolves issue #821

This PR enhances the Shape class by adding a new function to classify mode shapes into "Lateral," "Axial," or "Torsional." With the new attribute `mode_type`, it is now possible to identify the mode shape in the Campbell diagram for the 6 dof model, leading to the creation of two new labels: “Axial” and “Torsional.”

Additionally, an issue was observed in the eigen solver results for certain 6 dof model cases. The `sigma` argument in `las.eigs()` function was previously set to 0, which resulted in poor accuracy. By adjusting `sigma` to a value slightly greater than 0, the accuracy of the results has improved. However, it is not yet clear whether the value now assumed for sigma presents good results for other cases. For more details about this parameter, refer to the solver documentation  [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigs.html#scipy.sparse.linalg.eigs).

The values in the hover info of critical speeds were fixed, and I suggested changing the x-axis of the Campbell diagram to “Rotor Speed”.

Some comparison of results are shown below:

## Rotor model from tutorial
![6_dof_without](https://github.com/petrobras/ross/assets/82293939/4dd8d452-ae53-4b61-b90c-f6cf11d35c33)
![tutorial_3_zoom](https://github.com/petrobras/ross/assets/82293939/0a52f555-27d4-455e-a6b8-930738bc056a)

## LMEst 2 disk rotor
![4_dof](https://github.com/petrobras/ross/assets/82293939/c941c4a6-5dca-4321-9ff5-1a419cb92bc7)
![6_dof_with](https://github.com/petrobras/ross/assets/82293939/e6cc0f6e-45fa-4d27-a479-d437ef3b29bb)
![6_dof_without](https://github.com/petrobras/ross/assets/82293939/27c00bd2-ccc6-4386-84e7-55488228a3a6)

## Gp68
![4_dof](https://github.com/petrobras/ross/assets/82293939/0abea146-0214-4caa-98e1-bb4b62f2f531)
![6_dof_with](https://github.com/petrobras/ross/assets/82293939/f253df06-504e-47da-9226-dbe62402d556)
![6_dof_without](https://github.com/petrobras/ross/assets/82293939/9afe52c7-f739-41e2-b3bb-194636e645b6)



