### PR TITLE
Fix critical points in run_ucs

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2322,8 +2322,10 @@ class Rotor(object):
             if not isinstance(bearing, SealElement):
                 bearings_elements.append(bearing)
 
+        bearing_class = BearingElement6DoF if self.number_dof == 6 else BearingElement
+
         for i, k in enumerate(stiffness_log):
-            bearings = [BearingElement(b.n, kxx=k, cxx=0) for b in bearings_elements]
+            bearings = [bearing_class(b.n, kxx=k, cxx=0) for b in bearings_elements]
             rotor = self.__class__(self.shaft_elements, self.disk_elements, bearings)
             modal = rotor.run_modal(
                 speed=0, num_modes=num_modes, synchronous=synchronous
@@ -2369,7 +2371,7 @@ class Rotor(object):
 
                         # create bearing
                         bearings = [
-                            BearingElement(b.n, kxx=k, cxx=0) for b in bearings_elements
+                            bearing_class(b.n, kxx=k, cxx=0) for b in bearings_elements
                         ]
 
                         # create rotor


### PR DESCRIPTION
When I was fixing some pytest warnings related to PR #1063, I realized that there was a bug in the `run_ucs()` function. As can be seen in the figure below, critical points will only be saved if the `intersection()` function returns `x` and `y` as length-1 arrays. If this function returns arrays with more than one element, the `float()` function will not work, and the try block will be skipped.
![Bug](https://github.com/petrobras/ross/assets/82293939/d548f3ac-7956-4254-8984-75e7c8276dc1)

I also had to modify the last changes made in PR #1062 to work with the 6 dof model. I came up with the following code:
```python
bearing_class = BearingElement6DoF if self.number_dof == 6 else BearingElement
...
  bearings = [bearing_class(b.n, kxx=k, cxx=0) for b in bearings_elements]
```
After fixing these issues, it is possible to see the critical points in the UCS map:

## Previously
![ucs_map](https://github.com/petrobras/ross/assets/82293939/bb9786fd-7385-4ff7-a79e-d64a0e0b5663)

## After modifications
![ucs_map_fixed](https://github.com/petrobras/ross/assets/82293939/84655985-126f-448e-88bb-0d1b78c1380e)


