### PR TITLE
Fix method of saving .toml file for the 6dof model

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1882,9 +1882,6 @@ class BearingElement6DoF(BearingElement):
                         " must have the same dimension"
                     )
 
-    def __hash__(self):
-        return hash(self.tag)
-
     def __repr__(self):
         """Return a string representation of a bearing element.
 
@@ -1980,99 +1977,8 @@ class BearingElement6DoF(BearingElement):
             return init_args_comparison and attributes_comparison
         return False
 
-    def save(self, file):
-        try:
-            data = toml.load(file)
-        except FileNotFoundError:
-            data = {}
-
-        # remove some info before saving
-        brg_data = self.__dict__.copy()
-        params_to_remove = [
-            "kxx_interpolated",
-            "kyy_interpolated",
-            "kxy_interpolated",
-            "kyx_interpolated",
-            "kzz_interpolated",
-            "cxx_interpolated",
-            "cyy_interpolated",
-            "cxy_interpolated",
-            "cyx_interpolated",
-            "czz_interpolated",
-            "dof_global_index",
-        ]
-        for p in params_to_remove:
-            brg_data.pop(p)
-
-        # change np.array to lists so that we can save in .toml as list(floats)
-        params = [
-            "kxx",
-            "kyy",
-            "kxy",
-            "kyx",
-            "kzz",
-            "cxx",
-            "cyy",
-            "cxy",
-            "cyx",
-            "czz",
-            "mxx",
-            "myy",
-            "mxy",
-            "myx",
-            "mzz",
-            "frequency",
-        ]
-        for p in params:
-            try:
-                brg_data[p] = [float(i) for i in brg_data[p]]
-            except TypeError:
-                pass
-
-        data[f"{self.__class__.__name__}_{self.tag}"] = brg_data
-
-        with open(file, "w") as f:
-            toml.dump(data, f)
-
-    @classmethod
-    def load(cls, file):
-        data = toml.load(file)
-        # extract single dictionary in the data
-        data = list(data.values())[0]
-        params = [
-            "kxx",
-            "kyy",
-            "kxy",
-            "kyx",
-            "kzz",
-            "cxx",
-            "cyy",
-            "cxy",
-            "cyx",
-            "czz",
-            "mxx",
-            "myy",
-            "mxy",
-            "myx",
-            "mzz",
-            "frequency",
-            "n",
-            "tag",
-            "n_link",
-            "scale_factor",
-        ]
-        kwargs = {}
-        for p in params:
-            try:
-                kwargs[p] = data.pop(p)
-            except KeyError:
-                pass
-
-        bearing = cls(**kwargs)
-        for k, v in data.items():
-            setattr(bearing, k, v)
-
-        return bearing
+    def __hash__(self):
+        return hash(self.tag)
 
     def dof_mapping(self):
         """Degrees of freedom mapping.

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -168,7 +168,7 @@ class Rotor(object):
             if sh.n is None:
                 sh.n = i
             if sh.tag is None:
-                sh.tag = sh.__class__.__name__ + " " + str(i)
+                sh.tag = "ShaftElement " + str(i)
 
         if disk_elements is None:
             disk_elements = []
@@ -185,10 +185,11 @@ class Rotor(object):
             # add n_l and n_r to bearing elements
             brg.n_l = brg.n
             brg.n_r = brg.n
-            if not isinstance(brg, SealElement) and brg.tag is None:
-                brg.tag = "Bearing " + str(i)
-            elif isinstance(brg, SealElement) and brg.tag is None:
-                brg.tag = "Seal " + str(i)
+            if brg.tag is None:
+                if isinstance(brg, SealElement):
+                    brg.tag = "Seal " + str(i)
+                else:
+                    brg.tag = "Bearing " + str(i)
 
         for i, p_mass in enumerate(point_mass_elements):
             if p_mass.tag is None:


### PR DESCRIPTION
Closes #1069

After fixing this issue, it is possible to load the .toml file:

![save-6dof-toml_fixed](https://github.com/petrobras/ross/assets/82293939/d8e29664-3669-42e8-a032-b5cca425f122)

![save-6dof-toml_working](https://github.com/petrobras/ross/assets/82293939/b1872a85-7de0-41a8-8a4d-6bf7fff45111)
