### PR TITLE
Change plot with mode shape

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt README.md LICENSE ross/new_units.txt ross/available_materials.toml
 include tools/data/c123701 tools/data/injection tools/data/PAPADOPOULOS_c.mat tools/data/PAPADOPOULOS.csv tools/data/rotor_example 
+recursive-include ross/assets *

--- a/ross/assets/default.css
+++ b/ross/assets/default.css
@@ -1,0 +1,9 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: white;
+}

--- a/ross/assets/plot_with_mode_shape.css
+++ b/ross/assets/plot_with_mode_shape.css
@@ -1,0 +1,30 @@
+.campbell-mode-shape {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100vw;
+    height: 100vh;
+    justify-content: center;
+}
+
+.campbell-mode-shape > * {
+    width: 100%;
+    height: 50%;
+    min-height: 768px;
+    padding: 5px;
+}
+
+.campbell-mode-shape > *:first-child {
+    min-height: 468px;
+    width: 98%;
+}
+
+@media (min-width: 1200px) {
+    .campbell-mode-shape > * {
+        height: 100%;
+        width: 40%;
+    }
+    
+    .campbell-mode-shape > *:first-child {
+        width: 60%;
+    }
+}

--- a/ross/results.py
+++ b/ross/results.py
@@ -1669,6 +1669,7 @@ class CampbellResults(Results):
                 x=0.5,
                 yanchor="bottom",
                 y=-0.3,
+                yref="container",
             ),
             **kwargs,
         )
@@ -1757,9 +1758,7 @@ class CampbellResults(Results):
         except ImportError:
             raise ImportError("Please install dash to use this feature.")
 
-        campbell_layout = dict(
-            margin=dict(l=0, r=0, t=30, b=0), legend=dict(yref="container")
-        )
+        campbell_layout = dict(margin=dict(l=0, r=0, t=30, b=0))
 
         mode_3d_layout = dict(
             margin=dict(l=0, r=0, t=30, b=0),

--- a/ross/results.py
+++ b/ross/results.py
@@ -1785,7 +1785,7 @@ class CampbellResults(Results):
         plot_mode_3d = update_mode_3d()
 
         # Initialize the Dash app
-        app = Dash("CampbellResults.plot_with_mode_shape")
+        app = Dash("ross")
 
         # Layout of the app
         app.layout = html.Div(

--- a/ross/results.py
+++ b/ross/results.py
@@ -1805,6 +1805,7 @@ class CampbellResults(Results):
                     ],
                 ),
             ],
+            className="campbell-mode-shape",
         )
 
         # Callback to update plot_mode_3d based on campbell diagram click

--- a/ross/results.py
+++ b/ross/results.py
@@ -1739,7 +1739,95 @@ class CampbellResults(Results):
 
         return camp_fig, update_mode_3d
 
-    def plot_with_mode_shape(
+    def plot_with_mode_shape_Dash(
+        self,
+        harmonics=[1],
+        frequency_units="rad/s",
+        damping_parameter="log_dec",
+        frequency_range=None,
+        damping_range=None,
+        fig=None,
+        **kwargs,
+    ):
+        try:
+            import random
+            from dash import Dash
+            from dash import dcc, html
+            from dash.dependencies import Input, Output
+        except ImportError:
+            raise ImportError("Please install dash to use this feature.")
+
+        campbell_layout = dict(
+            margin=dict(l=10, r=5, t=30, b=5), legend=dict(y=-0.12, x=0.5)
+        )
+
+        mode_3d_layout = dict(
+            margin=dict(l=20, r=5, t=30, b=5),
+            legend=dict(x=0.85, y=0.95),
+            scene=dict(camera=dict(eye=dict(x=2.5, y=2.75, z=2.25))),
+        )
+
+        camp_fig, update_mode_3d = self._plot_with_mode_shape(
+            harmonics=harmonics,
+            frequency_units=frequency_units,
+            damping_parameter=damping_parameter,
+            frequency_range=frequency_range,
+            damping_range=damping_range,
+            campbell_layout=campbell_layout,
+            mode_3d_layout=mode_3d_layout,
+            fig=fig,
+            **kwargs,
+        )
+
+        plot_mode_3d = update_mode_3d()
+
+        # Initialize the Dash app
+        app = Dash("ross")
+
+        # Layout of the app
+        app.layout = html.Div(
+            [
+                html.Div(
+                    [
+                        dcc.Graph(
+                            id="campbell", figure=camp_fig, style={"height": "100vh"}
+                        )
+                    ],
+                    style={
+                        "width": "50%",
+                        "display": "inline-block",
+                        "height": "100vh",
+                    },
+                ),
+                html.Div(
+                    [
+                        dcc.Graph(
+                            id="mode_3d", figure=plot_mode_3d, style={"height": "100vh"}
+                        )
+                    ],
+                    style={
+                        "width": "50%",
+                        "display": "inline-block",
+                        "height": "100vh",
+                        "float": "right",
+                    },
+                ),
+            ]
+        )
+
+        # Callback to update plot_mode_3d based on campbell diagram click
+        @app.callback(Output("mode_3d", "figure"), [Input("campbell", "clickData")])
+        def plot_with_mode_shape_callback(clickData):
+            if clickData is None:
+                return update_mode_3d()
+            else:
+                return update_mode_3d(clickData["points"][0])
+
+        # Run app
+        port = random.randint(8000, 9000)
+        app.run(port=port, debug=False, jupyter_mode="inline", jupyter_height=800)
+
+    def plot_with_mode_shape_VBox(
         self,
         harmonics=[1],
         frequency_units="rad/s",

--- a/ross/results.py
+++ b/ross/results.py
@@ -1739,7 +1739,7 @@ class CampbellResults(Results):
 
         return camp_fig, update_mode_3d
 
-    def plot_with_mode_shape_Dash(
+    def plot_with_mode_shape(
         self,
         harmonics=[1],
         frequency_units="rad/s",
@@ -1758,13 +1758,16 @@ class CampbellResults(Results):
             raise ImportError("Please install dash to use this feature.")
 
         campbell_layout = dict(
-            margin=dict(l=10, r=5, t=30, b=5), legend=dict(y=-0.12, x=0.5)
+            margin=dict(l=0, r=0, t=30, b=0), legend=dict(yref="container")
         )
 
         mode_3d_layout = dict(
-            margin=dict(l=20, r=5, t=30, b=5),
+            margin=dict(l=0, r=0, t=30, b=0),
             legend=dict(x=0.85, y=0.95),
-            scene=dict(camera=dict(eye=dict(x=2.5, y=2.75, z=2.25))),
+            scene=dict(
+                camera=dict(eye=dict(x=2.25, y=2.85, z=2.25)),
+                aspectratio=dict(x=2, y=0.9, z=0.9),
+            ),
         )
 
         camp_fig, update_mode_3d = self._plot_with_mode_shape(
@@ -1782,7 +1785,7 @@ class CampbellResults(Results):
         plot_mode_3d = update_mode_3d()
 
         # Initialize the Dash app
-        app = Dash("ross")
+        app = Dash("CampbellResults.plot_with_mode_shape")
 
         # Layout of the app
         app.layout = html.Div(
@@ -1790,29 +1793,18 @@ class CampbellResults(Results):
                 html.Div(
                     [
                         dcc.Graph(
-                            id="campbell", figure=camp_fig, style={"height": "100vh"}
+                            id="campbell", figure=camp_fig, style={"height": "100%"}
                         )
                     ],
-                    style={
-                        "width": "50%",
-                        "display": "inline-block",
-                        "height": "100vh",
-                    },
                 ),
                 html.Div(
                     [
                         dcc.Graph(
-                            id="mode_3d", figure=plot_mode_3d, style={"height": "100vh"}
+                            id="mode_3d", figure=plot_mode_3d, style={"height": "100%"}
                         )
                     ],
-                    style={
-                        "width": "50%",
-                        "display": "inline-block",
-                        "height": "100vh",
-                        "float": "right",
-                    },
                 ),
-            ]
+            ],
         )
 
         # Callback to update plot_mode_3d based on campbell diagram click
@@ -1825,57 +1817,7 @@ class CampbellResults(Results):
 
         # Run app
         port = random.randint(8000, 9000)
-        app.run(port=port, debug=False, jupyter_mode="inline", jupyter_height=800)
-
-    def plot_with_mode_shape_VBox(
-        self,
-        harmonics=[1],
-        frequency_units="rad/s",
-        damping_parameter="log_dec",
-        frequency_range=None,
-        damping_range=None,
-        fig=None,
-        **kwargs,
-    ):
-        try:
-            from ipywidgets import VBox
-        except ImportError:
-            raise ImportError("Please install ipywidgets to use this feature.")
-
-        camp_fig, update_mode_3d = self._plot_with_mode_shape(
-            harmonics=harmonics,
-            frequency_units=frequency_units,
-            damping_parameter=damping_parameter,
-            frequency_range=frequency_range,
-            damping_range=damping_range,
-            fig=fig,
-            **kwargs,
-        )
-        camp_fig = go.FigureWidget(camp_fig)
-
-        def plot_with_mode_shape_callback(trace, points, state):
-            point_idx = points.point_inds
-            if len(point_idx) > 0:
-                clicked_point = dict(x=trace.x[point_idx][0], y=trace.y[point_idx][0])
-
-                new_plot_mode_3d = update_mode_3d(clicked_point)
-                with plot_mode_3d.batch_update():
-                    # update title
-                    plot_mode_3d.layout["title"]["text"] = new_plot_mode_3d.layout[
-                        "title"
-                    ]["text"]
-                    for data, new_data in zip(plot_mode_3d_data, new_plot_mode_3d.data):
-                        for param in data:
-                            data[param] = new_data[param]
-
-        for scatter in camp_fig.data:
-            scatter.on_click(plot_with_mode_shape_callback)
-
-        plot_mode_3d = update_mode_3d()
-        plot_mode_3d = go.FigureWidget(plot_mode_3d)
-        plot_mode_3d_data = plot_mode_3d.data
-
-        return VBox([camp_fig, plot_mode_3d])
+        app.run(port=port, debug=False, jupyter_mode="inline", jupyter_height=768)
 
     def save(self, file):
         # TODO save modal results


### PR DESCRIPTION
The `plot_with_mode_shape()` method of `CampbellResults` has been enhanced to improve user interaction and code maintainability. Key modifications include:

- Creation of an internal function that returns the Campbell figure and the update function of the mode shape 3D figure based on the point clicked in the Campbell figure.
- Integration of Dash framework to plot both figures, enabling interactive user experience in both web browsers and Jupyter notebooks.
- Correction of the issue related to the positioning of the legend when broken into more than one line.