### PR TITLE
Change the X Axis (Rotor Speed) in Campbell Diagram

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1436,6 +1436,7 @@ class CampbellResults(Results):
         self,
         harmonics=[1],
         frequency_units="RPM",
+        speed_units="RPM",
         damping_parameter="log_dec",
         frequency_range=None,
         damping_range=None,
@@ -1451,6 +1452,9 @@ class CampbellResults(Results):
             The default is to plot 1x.
         frequency_units : str, optional
             Frequency units.
+            Default is "RPM".
+        speed_units : str, optional
+            Speed units.
             Default is "RPM".
         damping_parameter : str, optional
             Define which value to show for damping. We can use "log_dec" or "damping_ratio".
@@ -1489,7 +1493,8 @@ class CampbellResults(Results):
         ...     damping_parameter="damping_ratio",
         ...     frequency_range=Q_((2000, 10000), "RPM"),
         ...     damping_range=(-0.1, 100),
-        ...     frequency_units="RPM",
+        ...     frequency_units="Hz",
+        ...     speed_units="RPM",
         ... )
         """
         if damping_parameter == "log_dec":
@@ -1550,7 +1555,7 @@ class CampbellResults(Results):
         if len(crit_x) and len(crit_y):
             fig.add_trace(
                 go.Scatter(
-                    x=Q_(crit_x, "rad/s").to(frequency_units).m,
+                    x=Q_(crit_x, "rad/s").to(speed_units).m,
                     y=Q_(crit_y, "rad/s").to(frequency_units).m,
                     mode="markers",
                     marker=dict(symbol="x", color="black"),
@@ -1558,7 +1563,7 @@ class CampbellResults(Results):
                     legendgroup="Crit. Speed",
                     showlegend=True,
                     hovertemplate=(
-                        f"Frequency ({frequency_units}): %{{y:.2f}}<br>Critical Speed ({frequency_units}): %{{x:.2f}}"
+                        f"Frequency ({frequency_units}): %{{y:.2f}}<br>Critical Speed ({speed_units}): %{{x:.2f}}"
                     ),
                 )
             )
@@ -1607,7 +1612,7 @@ class CampbellResults(Results):
                 if any(check for check in mask):
                     fig.add_trace(
                         go.Scatter(
-                            x=Q_(speed_range[mask], "rad/s").to(frequency_units).m,
+                            x=Q_(speed_range[mask], "rad/s").to(speed_units).m,
                             y=Q_(w_i[mask], "rad/s").to(frequency_units).m,
                             marker=dict(
                                 symbol=mark,
@@ -1627,7 +1632,7 @@ class CampbellResults(Results):
         for j, h in enumerate(harmonics):
             fig.add_trace(
                 go.Scatter(
-                    x=Q_(speed_range, "rad/s").to(frequency_units).m,
+                    x=Q_(speed_range, "rad/s").to(speed_units).m,
                     y=h * Q_(speed_range, "rad/s").to(frequency_units).m,
                     mode="lines",
                     line=dict(dash="dashdot", color=list(tableau_colors)[j]),
@@ -1650,10 +1655,10 @@ class CampbellResults(Results):
             )
 
         fig.update_xaxes(
-            title_text=f"Rotor Speed ({frequency_units})",
+            title_text=f"Rotor Speed ({speed_units})",
             range=[
-                np.min(Q_(speed_range, "rad/s").to(frequency_units).m),
-                np.max(Q_(speed_range, "rad/s").to(frequency_units).m),
+                np.min(Q_(speed_range, "rad/s").to(speed_units).m),
+                np.max(Q_(speed_range, "rad/s").to(speed_units).m),
             ],
             exponentformat="none",
         )


### PR DESCRIPTION
Now, it's possible change the x axis (rotor speed) with variable `speed_units` in plot().

```python
import ross as rs
import numpy as np

Q_ = rs.Q_
rotor = rs.rotor_example()
speed = np.linspace(0, 400, 101)
camp = rotor.run_campbell(speed)
fig = camp.plot(
        harmonics=[1, 2],
        damping_parameter="damping_ratio",
        frequency_range=Q_((2000, 10000), "RPM"),
        damping_range=(-0.1, 100),
        frequency_units="Hz",
        speed_units="RPM",
        )
```

This PR resolve, issue #1087.