### PR TITLE
Fix plotting of modes

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1048,11 +1048,10 @@ class ModalResults(Results):
         -------
         whirl_w : array
             An array of strings indicating the direction of precession related
-            to the kappa_mode. Backward, Mixed or Forward depending on values
-            of kappa_mode.
+            to the mode shape. Backward, Mixed or Forward.
         """
         # whirl direction/values are methods because they are expensive.
-        whirl_w = [self.whirl(self.kappa_mode(wd)) for wd in range(len(self.wd))]
+        whirl_w = [self.shapes[wd].whirl for wd in range(len(self.wd))]
 
         return np.array(whirl_w)
 

--- a/ross/results.py
+++ b/ross/results.py
@@ -277,7 +277,7 @@ class Orbit(Results):
         # kappa encodes the relation between the axis and the precession.
         minor = np.sqrt(lam.min())
         major = np.sqrt(lam.max())
-        kappa = minor / major
+
         diff = nv - nu
 
         # we need to evaluate if 0 < nv - nu < pi.
@@ -289,10 +289,11 @@ class Orbit(Results):
         # if nv = nu or nv = nu + pi then the response is a straight line.
         if diff == 0 or diff == np.pi:
             kappa = 0
-
         # if 0 < nv - nu < pi, then a backward rotating mode exists.
         elif 0 < diff < np.pi:
-            kappa *= -1
+            kappa = -minor / major
+        else:
+            kappa = minor / major
 
         self.minor_axis = np.real(minor)
         self.major_axis = np.real(major)

--- a/ross/results.py
+++ b/ross/results.py
@@ -892,7 +892,6 @@ class ModalResults(Results):
         self.number_dof = number_dof
         self.modes = self.evectors[: self.ndof]
         self.shapes = []
-        kappa_modes = []
         for mode in range(len(self.wn)):
             self.shapes.append(
                 Shape(
@@ -904,42 +903,6 @@ class ModalResults(Results):
                     number_dof=self.number_dof,
                 )
             )
-            kappa_color = []
-            kappa_mode = self.kappa_mode(mode)
-            for kappa in kappa_mode:
-                kappa_color.append("blue" if kappa > 0 else "red")
-            kappa_modes.append(kappa_color)
-        self.kappa_modes = kappa_modes
-
-    @staticmethod
-    def whirl(kappa_mode):
-        """Evaluate the whirl of a mode.
-
-        Parameters
-        ----------
-        kappa_mode : list
-            A list with the value of kappa for each node related
-            to the mode/natural frequency of interest.
-
-        Returns
-        -------
-        whirldir : str
-            A string indicating the direction of precession related to the
-            kappa_mode.
-
-        Example
-        -------
-        >>> kappa_mode = [-5.06e-13, -3.09e-13, -2.91e-13, 0.011, -4.03e-13, -2.72e-13, -2.72e-13]
-        >>> ModalResults.whirl(kappa_mode)
-        'Forward'
-        """
-        if all(kappa >= -1e-3 for kappa in kappa_mode):
-            whirldir = "Forward"
-        elif all(kappa <= 1e-3 for kappa in kappa_mode):
-            whirldir = "Backward"
-        else:
-            whirldir = "Mixed"
-        return whirldir
 
     @staticmethod
     @np.vectorize

--- a/ross/results.py
+++ b/ross/results.py
@@ -1173,7 +1173,7 @@ class ModalResults(Results):
                     f"{title}<br>"
                     f"Mode {mode} | "
                     f"{frequency['speed']} {frequency_units} | "
-                    f"whirl: {self.whirl_direction()[mode]} | "
+                    f"whirl: {shape.whirl} | "
                     f"{frequency[frequency_type]} {frequency_units} | "
                     f"{damping_name} = {damping_value:.2f}"
                 ),
@@ -1268,7 +1268,7 @@ class ModalResults(Results):
                     f"{title}<br>"
                     f"Mode {mode} | "
                     f"{frequency['speed']} {frequency_units} | "
-                    f"whirl: {self.whirl_direction()[mode]} | "
+                    f"whirl: {shape.whirl} | "
                     f"{frequency[frequency_type]} {frequency_units} | "
                     f"{damping_name} = {damping_value:.2f}"
                 ),

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1399,7 +1399,7 @@ class Rotor(object):
         positive = [i for i in ind[len(a) // 2 :]]
         negative = [i for i in ind[: len(a) // 2]]
 
-        idx = np.array([positive, negative]).flatten()
+        idx = np.array([*positive, *negative])
 
         return idx
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -372,8 +372,6 @@ class Rotor(object):
         Ip_dsk = np.sum([disk.Ip for disk in self.disk_elements])
         self.Ip = Ip_sh + Ip_dsk
 
-        self._v0 = None  # used to call eigs
-
         # number of dofs
         half_ndof = self.number_dof / 2
         self.ndof = int(
@@ -1488,11 +1486,8 @@ class Rotor(object):
                         sigma=1,
                         ncv=4 * num_modes,
                         which="LM",
-                        v0=self._v0,
+                        v0=np.ones(min(A.shape)),
                     )
-                    # store v0 as a linear combination of the previously
-                    # calculated eigenvectors to use in the next call to eigs
-                    self._v0 = np.real(sum(evectors.T))
 
                 except las.ArpackError:
                     evalues, evectors = la.eig(A)
@@ -4020,8 +4015,6 @@ class CoAxialRotor(Rotor):
         Ip_sh = np.sum([sh.Im for sh in self.shaft_elements])
         Ip_dsk = np.sum([disk.Ip for disk in self.disk_elements])
         self.Ip = Ip_sh + Ip_dsk
-
-        self._v0 = None  # used to call eigs
 
         # number of dofs
         self.ndof = int(

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2001,8 +2001,8 @@ class Rotor(object):
             Unbalance magnitude (kg.m).
         unbalance_phase : list, float, pint.Quantity
             Unbalance phase (rad).
-        frequency : list, float, pint.Quantity
-            Array with the desired range of frequencies (rad/s).
+        frequency : list, pint.Quantity
+            List with the desired range of frequencies (rad/s).
         modes : list, optional
             Modes that will be used to calculate the frequency response
             (all modes will be used if a list is not given).

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1472,10 +1472,9 @@ class Rotor(object):
         if synchronous:
             evalues, evectors = la.eig(A)
 
-            idx = np.where(
-                (np.imag(evalues) != 0)
-                & (np.abs(np.real(evalues) / np.imag(evalues)) < 1000)
-            )[0]
+            idx = np.where(np.imag(evalues) != 0)[0]
+            evalues, evectors = filter_eigenpairs(evalues, evectors, idx)
+            idx = np.where(np.abs(np.real(evalues) / np.imag(evalues)) < 1000)[0]
             evalues, evectors = filter_eigenpairs(evalues, evectors, idx)
         else:
             if sparse:

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1482,13 +1482,11 @@ class Rotor(object):
                 try:
                     evalues, evectors = las.eigs(
                         A,
-                        k=2 * num_modes,
+                        k=min(2 * num_modes, max(num_modes, A.shape[0] - 2)),
                         sigma=1,
-                        ncv=4 * num_modes,
                         which="LM",
-                        v0=np.ones(min(A.shape)),
+                        v0=np.ones(A.shape[0]),
                     )
-
                 except las.ArpackError:
                     evalues, evectors = la.eig(A)
             else:

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1835,11 +1835,11 @@ def rotor_6dof():
 
 def test_modal_6dof(rotor_6dof):
     modal = rotor_6dof.run_modal(speed=0, sparse=False)
-    wn = np.array([0.0, 47.62138, 91.79647, 96.28891, 274.56591, 296.5005])
-    wd = np.array([0.01079, 47.62156, 91.79656, 96.289, 274.56607, 296.50068])
+    wn = np.array([47.62138, 91.79647, 96.28891, 274.56591, 296.5005])
+    wd = np.array([47.62156, 91.79656, 96.289, 274.56607, 296.50068])
 
-    assert_almost_equal(modal.wn[:6], wn, decimal=2)
-    assert_almost_equal(modal.wd[:6], wd, decimal=2)
+    assert_almost_equal(modal.wn[:5], wn, decimal=2)
+    assert_almost_equal(modal.wd[:5], wd, decimal=2)
 
 
 @pytest.fixture


### PR DESCRIPTION
Pull Request created to make corrections related to the plotting of modes in the `Results` class:

- [x] Removal of duplicate information related to whirl direction, which was inconsistent because the colors were not in accordance with the whirl direction shown in figures.
    - Only information from the `Shape` class was kept.
    - Unused methods were then removed.

- [x] Some adjustments were made to the `_eigen` method of the Rotor class.
    - To avoid constant changes in the plotting of the modes in each simulation, due to the random nature of the solver initialization, the parameter `v0` of the `las.eigs` function was set with a fixed array of values.
    - A limitation related to the amount of eigenvalues ​​to be found was applied when `sparse = True`.

- [x] As tests were carried out, the appearance of bugs and warnings were also corrected.
