### PR TITLE
Return kwargs in arguments of BearingElements

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -150,6 +150,7 @@ class BearingElement(Element):
         n_link=None,
         scale_factor=1,
         color="#355d7a",
+        **kwargs,
     ):
         if frequency is not None:
             self.frequency = np.array(frequency, dtype=np.float64)
@@ -475,6 +476,7 @@ class BearingElement(Element):
         diff_args = set(signature(self.__init__).parameters).difference(
             self.__dict__.keys()
         )
+        diff_args.discard("kwargs")
 
         class_name = (
             self.__class__.__name__
@@ -1195,6 +1197,7 @@ class SealElement(BearingElement):
         n_link=None,
         scale_factor=None,
         color="#77ACA2",
+        **kwargs,
     ):
         self.seal_leakage = seal_leakage
 
@@ -1303,6 +1306,7 @@ class BallBearingElement(BearingElement):
         n_link=None,
         scale_factor=1,
         color="#355d7a",
+        **kwargs,
     ):
         self.n_balls = n_balls
         self.d_balls = d_balls
@@ -1429,6 +1433,7 @@ class RollerBearingElement(BearingElement):
         n_link=None,
         scale_factor=1,
         color="#355d7a",
+        **kwargs,
     ):
         self.n_rollers = n_rollers
         self.l_rollers = l_rollers
@@ -1556,6 +1561,7 @@ class MagneticBearingElement(BearingElement):
         n_link=None,
         scale_factor=1,
         color="#355d7a",
+        **kwargs,
     ):
         self.g0 = g0
         self.i0 = i0
@@ -1733,6 +1739,7 @@ class CylindricalBearing(BearingElement):
         tag=None,
         scale_factor=1,
         color="#355d7a",
+        **kwargs,
     ):
         self.n = n
 
@@ -1828,6 +1835,7 @@ class CylindricalBearing(BearingElement):
             scale_factor=scale_factor,
             color=color,
             **coefficients_dict,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
In the last PR, I had accidentally removed the `kwargs`  from `BearingElements` input arguments, which ended up causing errors in some models. Therefore, I returned these arguments in this PR.