### PR TITLE
get speed in pint library for plot_deflected_shape function

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -4048,6 +4048,7 @@ class ForcedResponseResults(Results):
 
         return fig
 
+    @check_units
     def plot_deflected_shape(
         self,
         speed,


### PR DESCRIPTION
Now, it's possible receive the speed in "RPM" for function plot_deflected_shape(). As exemple:

```python
import ross as rs
from ross.units import  Q_
import numpy as np

rotor = rs.rotor_example()
speed = np.linspace(0, 1000, 101)
response = rotor.run_unbalance_response(
                                        node=3,
                                        unbalance_magnitude=10.0,
                                        unbalance_phase=0.0,
                                        frequency=speed)
response.plot_deflected_shape(speed=Q_(4774.64829, 'RPM')).show()
```

![image](https://github.com/user-attachments/assets/0dc9c744-af4a-463c-ada1-c396eeb2eab4)


This PR, resolve issue #1137 and discussion #1136 .