### PR TITLE
Drop deprecated heatmapgl traces in plotly v6.0.0

### DIFF
--- a/ross/plotly_theme.py
+++ b/ross/plotly_theme.py
@@ -232,24 +232,6 @@ pio.templates["ross"] = go.layout.Template(
                 "type": "heatmap",
             }
         ],
-        "heatmapgl": [
-            {
-                "colorbar": {"outlinewidth": 0, "ticks": ""},
-                "colorscale": [
-                    [0.0, "#0d0887"],
-                    [0.1111111111111111, "#46039f"],
-                    [0.2222222222222222, "#7201a8"],
-                    [0.3333333333333333, "#9c179e"],
-                    [0.4444444444444444, "#bd3786"],
-                    [0.5555555555555556, "#d8576b"],
-                    [0.6666666666666666, "#ed7953"],
-                    [0.7777777777777778, "#fb9f3a"],
-                    [0.8888888888888888, "#fdca26"],
-                    [1.0, "#f0f921"],
-                ],
-                "type": "heatmapgl",
-            }
-        ],
         "histogram": [
             {
                 "marker": {"colorbar": {"outlinewidth": 0, "ticks": ""}},


### PR DESCRIPTION
Resolves #1145

____

As mentioned in issue #1145 and in [change log](https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md)  of plotly, the deprecated `heatmapgl` traces were dropped from the API. 

To remove the resulting incompatibility in ROSS, the `heatmapgl` key was removed from the plotlty theme used in ROSS.