### PR TITLE
Update tutorial

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -710,6 +710,10 @@ class Rotor(object):
                             elm._n = elm.n
                             elm.n_l = elm.n
                             elm.n_r = elm.n + 1
+                        if elm in point_mass_elements:
+                            for brg in bearing_elements:
+                                if elm.n - 1 == brg.n_link:
+                                    brg.n_link += 1
 
             for j in range(i + 1, len(target_elements)):
                 if target_elements[j] == target_elements[i]:


### PR DESCRIPTION
Two examples were added to **Tutorial Part 1**:
- one demonstrating the use of `CouplingElement` as a lumped element, and
- another demonstrating the use of the `add_nodes()` method. 

During this process, a bug was discovered in the `add_nodes()` method related to bearing elements with `n_link`, which has now been fixed.