### PR TITLE
Adapt plot mode shapes for multirotor

### DIFF
--- a/ross/multi_rotor.py
+++ b/ross/multi_rotor.py
@@ -172,7 +172,7 @@ class MultiRotor(Rotor):
 
         idx1 = R1.nodes.index(gear_1.n)
         idx2 = R2.nodes.index(gear_2.n)
-        self.dz_pos = R1.nodes_pos[idx1] - R2.nodes_pos[idx2]
+        self.dz_pos = float(R1.nodes_pos[idx1] - R2.nodes_pos[idx2])
 
         R1_max_node = max([*R1.nodes, *R1.link_nodes])
         R2_min_node = min([*R2.nodes, *R2.link_nodes])
@@ -186,7 +186,7 @@ class MultiRotor(Rotor):
                 except:
                     pass
 
-        self.R2_nodes = [n + d_node for n in R2.nodes]
+        self.R2_nodes = [int(n + d_node) for n in R2.nodes]
 
         shaft_elements = [*R1.shaft_elements, *R2.shaft_elements]
         disk_elements = [*R1.disk_elements, *R2.disk_elements]

--- a/ross/results.py
+++ b/ross/results.py
@@ -553,7 +553,6 @@ class Shape(Results):
             for j in range(n_div):
                 n1 = get_node_index(j)
                 e1 = n1 - (j + 1)
-                print("")
 
                 for Le, n in zip(shaft_elements_length[e0:e1], nodes[n0:n1]):
                     node_pos = nodes_pos[n]
@@ -649,15 +648,15 @@ class Shape(Results):
 
         symbols = [
             "circle",
-            "circle-open",
             "square",
-            "square-open",
             "diamond",
+            "circle-open",
+            "square-open",
             "diamond-open",
         ]
 
         get_plot_mode = lambda i: (
-            dict(mode="lines+markers", marker=dict(symbol=symbols[i]))
+            dict(mode="lines+markers", marker=dict(symbol=symbols[i % len(symbols)]))
             if n_plot > 1
             else dict()
         )

--- a/ross/results.py
+++ b/ross/results.py
@@ -552,7 +552,8 @@ class Shape(Results):
             k = 0
             for j in range(n_div):
                 n1 = get_node_index(j)
-                e1 = n1 - 1
+                e1 = n1 - (j + 1)
+                print("")
 
                 for Le, n in zip(shaft_elements_length[e0:e1], nodes[n0:n1]):
                     node_pos = nodes_pos[n]
@@ -646,7 +647,14 @@ class Shape(Results):
             lambda i: intersecting_nodes[i] if i + 1 < n_plot else len(nodes_pos)
         )
 
-        symbols = ["circle", "square", "triangle-up", "triangle-down", "diamond"]
+        symbols = [
+            "circle",
+            "circle-open",
+            "square",
+            "square-open",
+            "diamond",
+            "diamond-open",
+        ]
 
         get_plot_mode = lambda i: (
             dict(mode="lines+markers", marker=dict(symbol=symbols[i]))
@@ -673,42 +681,47 @@ class Shape(Results):
         nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
 
         n_plot, get_node_index, get_plot_mode = self._fix_mode_shape_intersections()
+        showlegend = n_plot > 1
 
         if plot_dimension == 2:
             # Plot 2d
             n0 = 0
             for i in range(n_plot):
                 n1 = get_node_index(i)
-                extra_template = f"Rotor {i + 1} <br>" if n_plot > 1 else ""
+
+                legend_name = f"Rotor {i + 1}"
 
                 fig.add_trace(
                     go.Scatter(
                         x=nodes_pos[n0:n1],
                         y=rel_disp[n0:n1],
                         line=dict(color=self.color),
-                        showlegend=False,
-                        hovertemplate=(
-                            extra_template
-                            + f"Relative angle: %{{y:.2f}}<extra></extra>"
-                        ),
+                        hovertemplate=(f"Relative angle: %{{y:.2f}}<extra></extra>"),
+                        name=legend_name,
+                        legendgroup=legend_name,
+                        showlegend=showlegend,
                         **get_plot_mode(i),
                     )
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=nodes_pos[n0],
-                    y0=0,
-                    x1=nodes_pos[n0],
-                    y1=rel_disp[n0],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[nodes_pos[n0], nodes_pos[n0]],
+                        y=[0, rel_disp[n0]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=nodes_pos[n1 - 1],
-                    y0=0,
-                    x1=nodes_pos[n1 - 1],
-                    y1=rel_disp[n1 - 1],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[nodes_pos[n1 - 1], nodes_pos[n1 - 1]],
+                        y=[0, rel_disp[n1 - 1]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
 
                 n0 = n1
@@ -752,7 +765,8 @@ class Shape(Results):
                 xn = []
 
                 n1 = get_node_index(i)
-                extra_template = f" (Rotor {i + 1})" if n_plot > 1 else ""
+
+                legend_name = f"Rotor {i + 1}"
 
                 for n in range(n0, n1):
                     node_data.append(
@@ -762,30 +776,39 @@ class Shape(Results):
                             z=[0, 1],
                             mode="lines",
                             line=dict(width=2, color=self.color),
-                            showlegend=False,
                             name=f"Node {self.nodes[n]}",
                             hovertemplate=(
-                                f"Original position: {nodes_pos[n]:.2f} {length_units}"
-                                + extra_template
-                                + "<br>"
+                                f"Original position: {nodes_pos[n]:.2f} {length_units}<br>"
                                 + f"Relative displacement: {rel_disp[n]:.2f}"
                             ),
+                            legendgroup=legend_name,
+                            showlegend=False,
                         )
                     )
                     xn.append(zt[n])
 
                 n0 = n1
 
+                plot_mode = dict(
+                    mode="lines+markers", marker=dict(size=3, symbol="circle")
+                )
+
+                try:
+                    plot_mode["marker"]["symbol"] = get_plot_mode(i)["marker"]["symbol"]
+                except KeyError:
+                    pass
+
                 node_data.append(
                     go.Scatter3d(
                         x=xn,
                         y=np.zeros(len(nodes_pos)),
                         z=np.ones(len(nodes_pos)),
-                        mode="lines+markers",
                         line=dict(width=2, color=self.color),
-                        marker=dict(size=3),
-                        showlegend=False,
                         hoverinfo="none",
+                        name=legend_name,
+                        legendgroup=legend_name,
+                        showlegend=showlegend,
+                        **plot_mode,
                     )
                 )
 
@@ -890,42 +913,47 @@ class Shape(Results):
         nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
 
         n_plot, get_node_index, get_plot_mode = self._fix_mode_shape_intersections()
+        showlegend = n_plot > 1
 
         if plot_dimension == 2:
             # Plot 2d
             n0 = 0
             for i in range(n_plot):
                 n1 = get_node_index(i)
-                extra_template = f"Rotor {i + 1} <br>" if n_plot > 1 else ""
+
+                legend_name = f"Rotor {i + 1}"
 
                 fig.add_trace(
                     go.Scatter(
                         x=nodes_pos[n0:n1],
                         y=theta[n0:n1],
                         line=dict(color=self.color),
-                        showlegend=False,
-                        hovertemplate=(
-                            extra_template
-                            + f"Relative angle: %{{y:.2f}}<extra></extra>"
-                        ),
+                        hovertemplate=(f"Relative angle: %{{y:.2f}}<extra></extra>"),
+                        name=legend_name,
+                        legendgroup=legend_name,
+                        showlegend=showlegend,
                         **get_plot_mode(i),
                     )
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=nodes_pos[n0],
-                    y0=0,
-                    x1=nodes_pos[n0],
-                    y1=theta[n0],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[nodes_pos[n0], nodes_pos[n0]],
+                        y=[0, theta[n0]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=nodes_pos[n1 - 1],
-                    y0=0,
-                    x1=nodes_pos[n1 - 1],
-                    y1=theta[n1 - 1],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[nodes_pos[n1 - 1], nodes_pos[n1 - 1]],
+                        y=[0, theta[n1 - 1]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
 
                 n0 = n1
@@ -977,7 +1005,8 @@ class Shape(Results):
                 zn = []
 
                 n1 = get_node_index(i)
-                extra_template = f" (Rotor {i + 1})" if n_plot > 1 else ""
+
+                legend_name = f"Rotor {i + 1}"
 
                 for n in range(n0, n1):
                     node_data.append(
@@ -987,16 +1016,15 @@ class Shape(Results):
                             z=[0, yt[j, n]],
                             mode="lines",
                             line=dict(width=2, color=self.color),
-                            showlegend=False,
                             name=f"Node {self.nodes[n]}",
                             hovertemplate=(
-                                "Nodal position: %{x:.2f}"
-                                + extra_template
-                                + "<br>"
+                                "Nodal position: %{x:.2f}<br>"
                                 + "X - Displacement: %{y:.2f}<br>"
                                 + "Y - Displacement: %{z:.2f}<br>"
                                 + f"Relative angle: {theta[n]:.2f}"
                             ),
+                            legendgroup=legend_name,
+                            showlegend=False,
                         )
                     )
                     xn.append(nodes_pos[n])
@@ -1008,6 +1036,7 @@ class Shape(Results):
                 plot_mode = dict(
                     mode="lines+markers", marker=dict(size=3, symbol="circle")
                 )
+
                 try:
                     plot_mode["marker"]["symbol"] = get_plot_mode(i)["marker"]["symbol"]
                 except KeyError:
@@ -1019,8 +1048,10 @@ class Shape(Results):
                         y=yn,
                         z=zn,
                         line=dict(width=2, color=self.color),
-                        showlegend=False,
                         hoverinfo="none",
+                        name=legend_name,
+                        legendgroup=legend_name,
+                        showlegend=showlegend,
                         **plot_mode,
                     )
                 )
@@ -1141,43 +1172,50 @@ class Shape(Results):
 
             n_plot, get_node_index, get_plot_mode = self._fix_mode_shape_intersections()
             aux = len(zn) // len(self.shaft_elements_length)
+            showlegend = n_plot > 1
 
             n0 = 0
             for i in range(n_plot):
                 n1 = (get_node_index(i) - (i + 1)) * aux
-                extra_template = f"Rotor {i + 1} <br>" if n_plot > 1 else ""
+
+                legend_name = f"Rotor {i + 1}"
 
                 fig.add_trace(
                     go.Scatter(
                         x=zn[n0:n1],
                         y=values[n0:n1],
                         line=dict(color=self.color),
-                        name=f"{orientation}",
-                        showlegend=False,
                         customdata=major_angle[n0:n1],
                         hovertemplate=(
-                            extra_template
-                            + f"Displacement: %{{y:.2f}}<br>"
+                            f"Displacement: %{{y:.2f}}<br>"
                             + f"Angle {phase_units}: %{{customdata:.2f}}"
                         ),
+                        name=f"{orientation}",
+                        legendgrouptitle=dict(text=legend_name),
+                        legendgroup=legend_name,
+                        showlegend=showlegend,
                         **get_plot_mode(i),
                     ),
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=zn[n0],
-                    y0=0,
-                    x1=zn[n0],
-                    y1=values[n0],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[zn[n0], zn[n0]],
+                        y=[0, values[n0]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
-                fig.add_shape(
-                    type="line",
-                    x0=zn[n1 - 1],
-                    y0=0,
-                    x1=zn[n1 - 1],
-                    y1=values[n1 - 1],
-                    line=dict(color=self.color, dash="dash"),
+                fig.add_trace(
+                    go.Scatter(
+                        x=[zn[n1 - 1], zn[n1 - 1]],
+                        y=[0, values[n1 - 1]],
+                        mode="lines",
+                        line=dict(color=self.color, dash="dash"),
+                        legendgroup=legend_name,
+                        showlegend=False,
+                    )
                 )
 
                 n0 = n1

--- a/ross/results.py
+++ b/ross/results.py
@@ -646,11 +646,15 @@ class Shape(Results):
             lambda i: intersecting_nodes[i] if i + 1 < n_plot else len(nodes_pos)
         )
 
-        colors = list(tableau_colors.values())
+        symbols = ["circle", "square", "triangle-up", "triangle-down", "diamond"]
 
-        get_color = lambda i: self.color if i == 0 else colors[::-1][i - 1]
+        get_mode_plot = lambda i: (
+            dict(mode="lines+markers", marker=dict(symbol=symbols[i]))
+            if n_plot > 1
+            else dict(mode="lines")
+        )
 
-        return n_plot, get_node_index, get_color
+        return n_plot, get_node_index, get_mode_plot
 
     def _plot_axial(
         self, plot_dimension=None, animation=False, length_units="m", fig=None
@@ -668,23 +672,22 @@ class Shape(Results):
 
         nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
 
-        n_plot, get_node_index, get_color = self._fix_mode_shape_intersections()
+        n_plot, get_node_index, get_mode_plot = self._fix_mode_shape_intersections()
 
         if plot_dimension == 2:
             # Plot 2d
             n0 = 0
             for i in range(n_plot):
                 n1 = get_node_index(i)
-                color = get_color(i)
 
                 fig.add_trace(
                     go.Scatter(
                         x=nodes_pos[n0:n1],
                         y=rel_disp[n0:n1],
-                        mode="lines",
-                        line=dict(color=color),
+                        line=dict(color=self.color),
                         showlegend=False,
-                        hovertemplate=(f"Relative angle: %{{y:.2f }}<extra></extra>"),
+                        hovertemplate=(f"Relative angle: %{{y:.2f}}<extra></extra>"),
+                        **get_mode_plot(i),
                     )
                 )
                 fig.add_shape(
@@ -693,7 +696,7 @@ class Shape(Results):
                     y0=0,
                     x1=nodes_pos[n0],
                     y1=rel_disp[n0],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
                 fig.add_shape(
                     type="line",
@@ -701,7 +704,7 @@ class Shape(Results):
                     y0=0,
                     x1=nodes_pos[n1 - 1],
                     y1=rel_disp[n1 - 1],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
 
                 n0 = n1
@@ -745,7 +748,6 @@ class Shape(Results):
                 xn = []
 
                 n1 = get_node_index(i)
-                color = get_color(i)
 
                 for n in range(n0, n1):
                     node_data.append(
@@ -754,7 +756,7 @@ class Shape(Results):
                             y=[0, 0],
                             z=[0, 1],
                             mode="lines",
-                            line=dict(width=2, color=color),
+                            line=dict(width=2, color=self.color),
                             showlegend=False,
                             name=f"Node {self.nodes[n]}",
                             hovertemplate=(
@@ -773,7 +775,7 @@ class Shape(Results):
                         y=np.zeros(len(nodes_pos)),
                         z=np.ones(len(nodes_pos)),
                         mode="lines+markers",
-                        line=dict(width=2, color=color),
+                        line=dict(width=2, color=self.color),
                         marker=dict(size=3),
                         showlegend=False,
                         hoverinfo="none",
@@ -880,23 +882,22 @@ class Shape(Results):
 
         nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
 
-        n_plot, get_node_index, get_color = self._fix_mode_shape_intersections()
+        n_plot, get_node_index, get_mode_plot = self._fix_mode_shape_intersections()
 
         if plot_dimension == 2:
             # Plot 2d
             n0 = 0
             for i in range(n_plot):
                 n1 = get_node_index(i)
-                color = get_color(i)
 
                 fig.add_trace(
                     go.Scatter(
                         x=nodes_pos[n0:n1],
                         y=theta[n0:n1],
-                        mode="lines",
-                        line=dict(color=color),
+                        line=dict(color=self.color),
                         showlegend=False,
                         hovertemplate=(f"Relative angle: %{{y:.2f}}<extra></extra>"),
+                        **get_mode_plot(i),
                     )
                 )
                 fig.add_shape(
@@ -905,7 +906,7 @@ class Shape(Results):
                     y0=0,
                     x1=nodes_pos[n0],
                     y1=theta[n0],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
                 fig.add_shape(
                     type="line",
@@ -913,7 +914,7 @@ class Shape(Results):
                     y0=0,
                     x1=nodes_pos[n1 - 1],
                     y1=theta[n1 - 1],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
 
                 n0 = n1
@@ -965,7 +966,6 @@ class Shape(Results):
                 zn = []
 
                 n1 = get_node_index(i)
-                color = get_color(i)
 
                 for n in range(n0, n1):
                     node_data.append(
@@ -974,7 +974,7 @@ class Shape(Results):
                             y=[0, xt[j, n]],
                             z=[0, yt[j, n]],
                             mode="lines",
-                            line=dict(width=2, color=color),
+                            line=dict(width=2, color=self.color),
                             showlegend=False,
                             name=f"Node {self.nodes[n]}",
                             hovertemplate=(
@@ -997,7 +997,7 @@ class Shape(Results):
                         y=yn,
                         z=zn,
                         mode="lines+markers",
-                        line=dict(width=2, color=color),
+                        line=dict(width=2, color=self.color),
                         marker=dict(size=3),
                         showlegend=False,
                         hoverinfo="none",
@@ -1118,20 +1118,18 @@ class Shape(Results):
             else:
                 raise ValueError(f"Invalid orientation {orientation}.")
 
-            n_plot, get_node_index, get_color = self._fix_mode_shape_intersections()
+            n_plot, get_node_index, get_mode_plot = self._fix_mode_shape_intersections()
             aux = len(zn) // len(self.shaft_elements_length)
 
             n0 = 0
             for i in range(n_plot):
                 n1 = (get_node_index(i) - (i + 1)) * aux
-                color = get_color(i)
 
                 fig.add_trace(
                     go.Scatter(
                         x=zn[n0:n1],
                         y=values[n0:n1],
-                        mode="lines",
-                        line=dict(color=color),
+                        line=dict(color=self.color),
                         name=f"{orientation}",
                         showlegend=False,
                         customdata=major_angle[n0:n1],
@@ -1139,6 +1137,7 @@ class Shape(Results):
                             f"Displacement: %{{y:.2f}}<br>"
                             + f"Angle {phase_units}: %{{customdata:.2f}}"
                         ),
+                        **get_mode_plot(i),
                     ),
                 )
                 fig.add_shape(
@@ -1147,7 +1146,7 @@ class Shape(Results):
                     y0=0,
                     x1=zn[n0],
                     y1=values[n0],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
                 fig.add_shape(
                     type="line",
@@ -1155,7 +1154,7 @@ class Shape(Results):
                     y0=0,
                     x1=zn[n1 - 1],
                     y1=values[n1 - 1],
-                    line=dict(color=color, dash="dash"),
+                    line=dict(color=self.color, dash="dash"),
                 )
 
                 n0 = n1
@@ -1299,7 +1298,7 @@ class Shape(Results):
             if n == 0:
                 initial_state = orbit_data
 
-        n_plot, get_node_index, get_color = self._fix_mode_shape_intersections()
+        n_plot, get_node_index, _ = self._fix_mode_shape_intersections()
         aux = len(zn) // len(self.shaft_elements_length)
 
         n0 = 0

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -1682,9 +1682,9 @@ def test_deflected_shape(rotor7):
             4.88678837e-05,
         ]
     )
-    assert_allclose(fig.data[-3]["x"][:8], expected_x, rtol=1e-4)
-    assert_allclose(fig.data[-3]["y"][:8], expected_y, rtol=1e-4)
-    assert_allclose(fig.data[-3]["z"][:8], expected_z, rtol=1e-4)
+    assert_allclose(fig.data[-4]["x"][:8], expected_x, rtol=1e-4)
+    assert_allclose(fig.data[-4]["y"][:8], expected_y, rtol=1e-4)
+    assert_allclose(fig.data[-4]["z"][:8], expected_z, rtol=1e-4)
 
 
 def test_global_index():


### PR DESCRIPTION
Resolves #1168

The plot functions of the mode shapes have been adapted to improve visibility in the case of multirotors.

To differentiate the modes of each coupled rotor, markers have been added to the curves (2d and 3d).
If the model is only a single rotor and not a multirotor, the curves will not show these markers.

![newplot](https://github.com/user-attachments/assets/56604f9b-3a06-4bb4-95b4-701409251687)

![newplot](https://github.com/user-attachments/assets/769aa2dc-dad0-4f60-9759-fec45a633636)

![newplot](https://github.com/user-attachments/assets/004d30a7-993b-4ce4-be77-b471e9fdd160)

