### PR TITLE
Create function to convert 6dof rotor to torsional

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -1950,9 +1950,9 @@ class CampbellResults(Results):
     run_modal : callable
         Function that runs the modal analysis.
     campbell_torsional : CampbellResults, optional
-        If True, the Campbell Diagram includes separated torsional modes.
-        Default is None, which means that torsional modes obtained in the
-        separated analysis are not included.
+        If True, the Campbell Diagram includes torsional modes of separated
+        analysis. Default is None, which means that torsional modes obtained
+        in the separated analysis are not included.
 
     Returns
     -------
@@ -2280,7 +2280,7 @@ class CampbellResults(Results):
 
             for trace in torsional_fig.data:
                 if trace.name == "Torsional":
-                    new_name = "Separated Torsional Analysis"
+                    new_name = "Torsional Analysis"
                     trace.name = new_name
                     trace.legendgroup = new_name
                     trace.marker.symbol = "bowtie-open"
@@ -2336,7 +2336,7 @@ class CampbellResults(Results):
             speed = clicked_point["x"]
             natural_frequency = clicked_point["y"]
 
-            if camp_fig.data[curve_id].name == "Separated Torsional Analysis":
+            if camp_fig.data[curve_id].name == "Torsional Analysis":
                 update_func = self.campbell_torsional._update_plot_mode_3d
             else:
                 update_func = self._update_plot_mode_3d

--- a/ross/results.py
+++ b/ross/results.py
@@ -1945,6 +1945,13 @@ class CampbellResults(Results):
         Array with the whirl values (0, 0.5 or 1)
     modal_results : dict
         Dictionary with the modal results for each speed in the speed range.
+    numer_dof : int
+        Number of degrees of freedom of model.
+    run_modal : callable
+        Function that runs the modal analysis.
+    campbell_torsional : CampbellResults, optional
+        If True, the Campbell Diagram includes separated torsional modes.
+        Default is None, which means that torsional modes are not included.
 
     Returns
     -------

--- a/ross/results.py
+++ b/ross/results.py
@@ -461,7 +461,9 @@ class Shape(Results):
         self.zn = None
         self.major_axis = None
         self._classify()
-        self._calculate()
+
+        if number_dof > 3:
+            self._calculate()
 
     def _classify(self):
         self.mode_type = "Lateral"
@@ -487,6 +489,10 @@ class Shape(Results):
             elif torsional_percent > 0.9:
                 self.mode_type = "Torsional"
                 self.color = tableau_colors["green"]
+
+        elif self.number_dof == 1:
+            self.mode_type = "Torsional"
+            self.color = tableau_colors["green"]
 
     def _calculate_orbits(self):
         orbits = []
@@ -805,6 +811,9 @@ class Shape(Results):
         size = len(self.vector)
         torsional_dofs = np.arange(5, size, self.number_dof)
 
+        if self.number_dof == 1:
+            torsional_dofs = np.arange(0, size, self.number_dof)
+
         theta = np.abs(self.vector[torsional_dofs]) * np.angle(
             self.vector[torsional_dofs]
         )
@@ -989,11 +998,6 @@ class Shape(Results):
         fig : Plotly graph_objects.Figure()
             The figure object with the plot.
         """
-        xn = self.major_x.copy()
-        yn = self.major_y.copy()
-        zn = self.zn.copy()
-        nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
-
         if fig is None:
             fig = go.Figure()
 
@@ -1004,6 +1008,11 @@ class Shape(Results):
             self._plot_axial(plot_dimension=2, length_units=length_units, fig=fig)
 
         else:
+            xn = self.major_x.copy()
+            yn = self.major_y.copy()
+            zn = self.zn.copy()
+            nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
+
             if orientation == "major":
                 values = self.major_axis.copy()
             elif orientation == "x":

--- a/ross/results.py
+++ b/ross/results.py
@@ -1951,7 +1951,8 @@ class CampbellResults(Results):
         Function that runs the modal analysis.
     campbell_torsional : CampbellResults, optional
         If True, the Campbell Diagram includes separated torsional modes.
-        Default is None, which means that torsional modes are not included.
+        Default is None, which means that torsional modes obtained in the
+        separated analysis are not included.
 
     Returns
     -------

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -1031,7 +1031,6 @@ class Rotor(object):
 
         return results
 
-    @lru_cache()
     def M(self, frequency=None, synchronous=False):
         """Mass matrix for an instance of a rotor.
 
@@ -1102,7 +1101,6 @@ class Rotor(object):
 
         return M0
 
-    @lru_cache()
     def K(self, frequency, ignore=()):
         """Stiffness matrix for an instance of a rotor.
 
@@ -1140,7 +1138,6 @@ class Rotor(object):
 
         return K0
 
-    @lru_cache()
     def Ksdt(self):
         """Dynamic stiffness matrix for an instance of a rotor.
 
@@ -1176,7 +1173,6 @@ class Rotor(object):
 
         return Ksdt0
 
-    @lru_cache()
     def C(self, frequency, ignore=()):
         """Damping matrix for an instance of a rotor.
 
@@ -1214,7 +1210,6 @@ class Rotor(object):
 
         return C0
 
-    @lru_cache()
     def G(self):
         """Gyroscopic matrix for an instance of a rotor.
 
@@ -1240,7 +1235,6 @@ class Rotor(object):
 
         return G0
 
-    @lru_cache()
     def A(self, speed=0, frequency=None, synchronous=False):
         """State space matrix for an instance of a rotor.
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -2680,6 +2680,11 @@ class Rotor(object):
             Choose between displaying results related to the undamped natural
             frequencies ("wn") or damped natural frequencies ("wd").
             The default is "wd".
+        torsional_analysis : bool, optional
+            If True, performs a separate torsional analysis and returns the
+            respective modes in the Campbell diagram. In this case, a system
+            with only torsional degrees of freedom is considered, thus
+            disregarding coupled modes (lateral + torsional). Default is False.
 
         Returns
         -------

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -951,7 +951,7 @@ def convert_6dof_to_torsional(rotor):
     True
     >>> M_tdof.shape
     (7, 7)
-    >>> len(M_4dof) == n_nodes * 1
+    >>> len(M_tdof) == n_nodes * 1
     True
     """
     # Copy the rotor object

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -929,8 +929,8 @@ def convert_6dof_to_torsional(rotor):
 
     Important Note:
     Some Rotor class methods, such as `run_ucs`, and `run_unbalance_response`, may not
-    work correctly with the modified rotor object. This is because these methods expect a
-    rotor with 6 dofs or at least 4 dofs.
+    work correctly with the modified rotor object. This is because these methods expect
+    a rotor with 6 dofs or at least 4 dofs.
 
     Parameters
     ----------

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -915,3 +915,58 @@ def convert_6dof_to_4dof(rotor):
     new_rotor.ndof = len(new_rotor.M())
 
     return new_rotor
+
+
+def convert_6dof_to_torsional(rotor):
+    """Convert a 6 dof rotor model to a model with only torsional dofs.
+
+    This function takes a 6 dof rotor model and modifies it by removing the axial and
+    lateral dofs. It adjusts the corresponding matrix methods to reflect this change.
+
+    Parameters
+    ----------
+    rotor: rs.Rotor
+        The rotor object of 6 dof model.
+
+    Returns
+    -------
+    new_rotor: rs.Rotor
+        The rotor object modified.
+
+    Examples
+    --------
+    >>> import ross as rs
+    >>> rotor = rs.rotor_example_6dof()
+    >>> rotor_mod = convert_6dof_to_torsional(rotor)
+    >>> n_nodes = rotor.nodes[-1] + 1
+    >>> M_6dof = rotor.M()
+    >>> M_tdof = rotor_mod.M()
+    >>> M_6dof.shape
+    (42, 42)
+    >>> len(M_6dof) == n_nodes * 6
+    True
+    >>> M_tdof.shape
+    (7, 7)
+    >>> len(M_4dof) == n_nodes * 1
+    True
+    """
+    # Copy the rotor object
+    new_rotor = copy(rotor)
+
+    # Create a list of dofs to remove (axial and lateral dofs)
+    dofs = [i for i in range(rotor.ndof) if (i - 5) % 6 != 0 or i < 5]
+
+    # Modify matrix methods to get 1 (torsional only) dof matrices
+    new_rotor.M = lambda frequency=None, synchronous=False: remove_dofs(
+        rotor.M(frequency=frequency, synchronous=synchronous), dofs
+    )
+    new_rotor.K = lambda frequency: remove_dofs(rotor.K(frequency), dofs)
+    new_rotor.Ksdt = lambda: remove_dofs(rotor.Ksdt(), dofs)
+    new_rotor.C = lambda frequency: remove_dofs(rotor.C(frequency), dofs)
+    new_rotor.G = lambda: remove_dofs(rotor.G(), dofs)
+
+    # Update number of dofs
+    new_rotor.number_dof = 1
+    new_rotor.ndof = len(new_rotor.M())
+
+    return new_rotor

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -927,6 +927,11 @@ def convert_6dof_to_torsional(rotor):
     This function takes a 6 dof rotor model and modifies it by removing the axial and
     lateral dofs. It adjusts the corresponding matrix methods to reflect this change.
 
+    Important Note:
+    Some Rotor class methods, such as `run_ucs`, and `run_unbalance_response`, may not
+    work correctly with the modified rotor object. This is because these methods expect a
+    rotor with 6 dofs or at least 4 dofs.
+
     Parameters
     ----------
     rotor: rs.Rotor

--- a/ross/utils.py
+++ b/ross/utils.py
@@ -910,6 +910,10 @@ def convert_6dof_to_4dof(rotor):
     new_rotor.C = lambda frequency: remove_dofs(rotor.C(frequency))
     new_rotor.G = lambda: remove_dofs(rotor.G())
 
+    # Because of lru_cache, we need to unwrap the methods
+    new_rotor.run_modal = new_rotor.run_modal.__wrapped__
+    new_rotor._run_freq_response = new_rotor._run_freq_response.__wrapped__
+
     # Update number of dofs
     new_rotor.number_dof = 4
     new_rotor.ndof = len(new_rotor.M())
@@ -964,6 +968,10 @@ def convert_6dof_to_torsional(rotor):
     new_rotor.Ksdt = lambda: remove_dofs(rotor.Ksdt(), dofs)
     new_rotor.C = lambda frequency: remove_dofs(rotor.C(frequency), dofs)
     new_rotor.G = lambda: remove_dofs(rotor.G(), dofs)
+
+    # Because of lru_cache, we need to unwrap the methods
+    new_rotor.run_modal = new_rotor.run_modal.__wrapped__
+    new_rotor._run_freq_response = new_rotor._run_freq_response.__wrapped__
 
     # Update number of dofs
     new_rotor.number_dof = 1


### PR DESCRIPTION
This PR introduces a new function to convert a 6DoF rotor representation into a model with only torsional DoFs. This utility will help simplify simulations or analyses where only torsional dynamics are relevant.

## Changes Made
- Added `convert_6dof_to_torsional()` function in _utils.py_
- Added option in `run_campbell()` to enable separated torsional analysis by setting `torsional_analysis=True` (results shown in the Campbell diagram)

## Notes
- While run_modal and `run_campbell` are expected to work with the converted rotor, other methods of the `Rotor` class—such as `run_ucs` and `run_unbalance_response`—may not function correctly with the rotor object returned by `convert_6dof_to_torsional`.
- The torsional modes included in the full (6DoF) analysis may differ from those obtained in the separated torsional analysis, as the latter ignores coupling effects between lateral and torsional dynamics.

https://github.com/user-attachments/assets/0f9d72e3-2edf-4bae-bb4c-b7e7366171b1
