### PR TITLE
Adjust save method for BearingElements

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -4,10 +4,11 @@ This module defines the BearingElement classes which will be used to represent t
 bearings and seals. There are 7 different classes to represent bearings options.
 """
 
-import numpy as np
 import toml
 import warnings
-from inspect import signature
+import sys
+import numpy as np
+from inspect import signature, isclass, getmembers
 from numpy.polynomial import Polynomial
 from plotly import graph_objects as go
 from scipy import interpolate as interpolate
@@ -478,9 +479,16 @@ class BearingElement(Element):
         )
         diff_args.discard("kwargs")
 
+        # If the bearing or seal element is implemented in other file
+        # we will consider the base class name to save element data
+        classes_in_module = getmembers(sys.modules[__name__], isclass)
+        classes_of_module = [
+            cls[1] for cls in classes_in_module if cls[1].__module__ == __name__
+        ]
+
         class_name = (
             self.__class__.__name__
-            if not diff_args
+            if not diff_args and self.__class__ in classes_of_module
             else self.__class__.__bases__[0].__name__
         )
 


### PR DESCRIPTION
Due to bugs involving specific types of bearings and seals, the save method had previously been modified so that each bearing element would be saved using the name of its specific class. However, this approach may cause issues for future classes that need to solve equations or perform optimizations to determine stiffness and damping coefficients.

The idea behind the save method was to simplify these processes. After initializing a class and saving it, the user shouldn't need to re-run code to reinitialize the coefficient values every time, and loading the saved _.toml_ file should be enough.

With that in mind, I’ve made some changes to the save method:
- If the class of the element (bearing or seal) is implemented in a module other than the default one, it will now be saved using the name of its parent class instead of its specific subclass.