### PR TITLE
Fix problem related to update_mode_3d

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -2526,9 +2526,12 @@ class CampbellResults(Results):
 
                 return mode_3d_fig
 
-            curve_id = clicked_point["curveNumber"]
             speed = clicked_point["x"]
             natural_frequency = clicked_point["y"]
+
+            curve_id = clicked_point.get(
+                "curveNumber", clicked_point.get("curve_number")
+            )
 
             if camp_fig.data[curve_id].name == "Torsional Analysis":
                 update_func = self.campbell_torsional._update_plot_mode_3d


### PR DESCRIPTION
This PR resolves an issue related to the `"curveNumber"` attribute in the `Campbell` figure within the `update_mode_3d` function. The attribute is named inconsistently across platforms:
- On Streamlit, it appears as "curve_number"
- On Dash, it is represented as "curveNumber"

This update introduces logic to handle both naming conventions to ensure cross-platform compatibility and prevent potential errors.