### PR TITLE
Fix numerical precision issues in crack test assertions

### DIFF
--- a/ross/tests/test_crack.py
+++ b/ross/tests/test_crack.py
@@ -95,8 +95,8 @@ def test_crack_mayes(rotor):
         ]
     )
 
-    assert_allclose(crack.Ko, Ko)
-    assert_allclose(crack.Kc, Kc)
+    assert_allclose(crack.Ko, Ko, rtol=1e-6, atol=1e-7)
+    assert_allclose(crack.Kc, Kc, rtol=1e-6, atol=1e-7)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Fix numerical precision issues in crack test assertions

## Problem

The `test_crack_mayes` function was failing due to floating-point precision errors when comparing matrices with expected zero values. The test was using `assert_allclose` without tolerance parameters, causing failures when computed values were very small numbers (e.g., `7.27e-08`) instead of exact zeros.

## Solution

Added appropriate tolerance parameters to `assert_allclose` calls:
- `rtol=1e-6`: Relative tolerance for non-zero values  
- `atol=1e-7`: Absolute tolerance to handle near-zero values

## Technical Details

When comparing matrices where expected values are exactly `0.0`, relative tolerance (`rtol`) alone produces infinite relative errors:

```
relative_error = |actual - expected| / |expected| = |7.27e-08 - 0| / |0| = inf
```

The `atol` parameter defines the absolute threshold below which differences between values are considered negligible.

## Changes

- Modified `assert_allclose(crack.Ko, Ko)` → `assert_allclose(crack.Ko, Ko, rtol=1e-6, atol=1e-7)`
- Modified `assert_allclose(crack.Kc, Kc)` → `assert_allclose(crack.Kc, Kc, rtol=1e-6, atol=1e-7)`

## Testing

✅ `pytest ross/tests/test_crack.py::test_crack_mayes` now passes  
✅ All other tests continue to pass