### PR TITLE
Fix add_nodes for conical shaft elements

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -726,8 +726,14 @@ class Rotor(object):
         for i in range(len(target_elements)):
             elem = target_elements[i]
 
-            left_elem = elem.create_modified(L=(elem.L - new_elems_length[i]))
-            right_elem = elem.create_modified(L=new_elems_length[i], n=(elem.n + 1))
+            left_length = elem.L - new_elems_length[i]
+            id_interp = np.interp(left_length, [0, elem.L], [elem.idl, elem.idr])
+            od_interp = np.interp(left_length, [0, elem.L], [elem.odl, elem.odr])
+
+            left_elem = elem.copy(L=left_length, idr=id_interp, odr=od_interp)
+            right_elem = elem.copy(
+                L=new_elems_length[i], idl=id_interp, odl=od_interp, n=(elem.n + 1)
+            )
 
             if left_elem.n != prev_left_node:
                 for elm in elements:

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -1171,7 +1171,7 @@ class ShaftElement(Element):
 
         return fig
 
-    def create_modified(self, **attributes):
+    def copy(self, **attributes):
         """Return a new shaft element based on the current instance.
 
         Any attribute passed as an argument will be used to modify the corresponding


### PR DESCRIPTION
Resolves #1218
___________
This PR fixes incorrect behavior in `Rotor.add_nodes` when applied to conical (tapered) shaft elements. The method now correctly interpolates diameters and lengths when splitting elements, preserving geometry and connectivity.

**Notes**
- Updated `add_nodes` to handle conical elements.
- Correct interpolation of inner/outer diameters and element lengths.
- Fixed geometry issues when inserting nodes into conical shaft elements and ensuring rotor models remain consistent.

**Example**
```python
import numpy as np
import ross as rs
from ross.materials import steel

L = 0.20

shaft_elements = [
    rs.ShaftElement(L=L, idl=0.0, odl=0.04, material=steel),
    rs.ShaftElement(L=L, idl=0.0, odl=0.04, material=steel),
    rs.ShaftElement(L=L, idl=0.0, odl=0.04, idr=0.0, odr=0.07, material=steel),
    rs.ShaftElement(L=L, idl=0.0, odl=0.07, material=steel),
    rs.ShaftElement(L=L, idl=0.0, odl=0.07, material=steel),
]

disk = rs.DiskElement(n=2, m=5.0, Ip=0.01, Id=0.02)
bearing0 = rs.BearingElement(n=0, kxx=1e6, kyy=1e6, cxx=100, frequency=[0])
bearing1 = rs.BearingElement(n=5, kxx=1e6, kyy=1e6, cxx=100, frequency=[0])

rotor = rs.Rotor(shaft_elements=shaft_elements,
                 disk_elements=[disk],
                 bearing_elements=[bearing0, bearing1],
                 tag="Rotor_with_conical_element")

new_rotor = rotor.add_nodes([0.5, 0.3, 0.66])
```

```python
rotor.plot_rotor().show()
```
<img width="853" height="386" alt="newplot(1)" src="https://github.com/user-attachments/assets/1235f887-0ea9-4f00-ab46-73b31b312212" />

```python
new_rotor.plot_rotor().show()
```
**Before:**
<img width="853" height="386" alt="newplot(2)" src="https://github.com/user-attachments/assets/80f2d940-ebe1-4dc1-9e5c-b67e79fc0a25" />

**Now fixed:**
<img width="853" height="386" alt="newplot(3)" src="https://github.com/user-attachments/assets/413c91c3-4f13-4a10-b054-782a2cbe2da8" />
