### PR TITLE
Add JSON save/load support alongside TOML

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -6,7 +6,6 @@ bearings and seals. There are 7 different classes to represent bearings options.
 
 import control as ct
 import numpy as np
-import toml
 import warnings
 from inspect import signature
 from prettytable import PrettyTable
@@ -553,8 +552,10 @@ class BearingElement(Element):
         return hash(self.tag)
 
     def save(self, file):
+        from ross.utils import load_data, dump_data
+
         try:
-            data = toml.load(file)
+            data = load_data(file)
         except FileNotFoundError:
             data = {}
 
@@ -570,7 +571,7 @@ class BearingElement(Element):
 
         brg_data = {arg: self.__dict__[arg] for arg in args}
 
-        # change np.array to lists so that we can save in .toml as list(floats)
+        # change np.array to lists so that we can save as list(floats)
         for k, v in brg_data.items():
             if isinstance(v, np.generic):
                 brg_data[k] = brg_data[k].item()
@@ -596,8 +597,7 @@ class BearingElement(Element):
 
         data[f"{class_name}_{self.tag}"] = brg_data
 
-        with open(file, "w") as f:
-            toml.dump(data, f)
+        dump_data(data, file)
 
     def dof_mapping(self):
         """Degrees of freedom mapping.

--- a/ross/coupling_element.py
+++ b/ross/coupling_element.py
@@ -5,7 +5,6 @@ between two rotor shafts, which add mainly stiffness, mass and inertia to the sy
 """
 
 import inspect
-import toml
 
 import numpy as np
 from plotly import graph_objects as go
@@ -212,18 +211,19 @@ class CouplingElement(ShaftElement):
         )
 
     def save(self, file):
+        from ross.utils import load_data, dump_data
+
         signature = inspect.signature(self.__init__)
         args_list = list(signature.parameters)
         args = {arg: getattr(self, arg) for arg in args_list}
 
         try:
-            data = toml.load(file)
+            data = load_data(file)
         except FileNotFoundError:
             data = {}
 
         data[f"{self.__class__.__name__}_{self.tag}"] = args
-        with open(file, "w") as f:
-            toml.dump(data, f)
+        dump_data(data, file)
 
     @classmethod
     def read_toml_data(cls, data):

--- a/ross/element.py
+++ b/ross/element.py
@@ -3,8 +3,9 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 
 import pandas as pd
-import toml
 import re
+
+from ross.utils import load_data, dump_data
 
 
 class Element(ABC):
@@ -19,9 +20,9 @@ class Element(ABC):
         self.tag = tag
 
     def save(self, file):
-        """Save the element in a .toml file.
+        """Save the element in a .toml or .json file.
 
-        This function will save the element to a .toml file.
+        This function will save the element to a .toml or .json file.
         The file will have all the argument's names and values that are needed to
         reinstantiate the element.
 
@@ -29,6 +30,7 @@ class Element(ABC):
         ----------
         file : str, pathlib.Path
             The name of the file the element will be saved in.
+            The format is determined by the file extension (.toml or .json).
 
         Examples
         --------
@@ -45,25 +47,24 @@ class Element(ABC):
         args_list = list(signature(self.__init__).parameters)
         args = {arg: getattr(self, arg) for arg in args_list}
         try:
-            data = toml.load(file)
+            data = load_data(file)
         except FileNotFoundError:
             data = {}
 
         data[f"{self.__class__.__name__}_{self.tag}"] = args
-        with open(file, "w") as f:
-            toml.dump(data, f)
+        dump_data(data, file)
 
     @classmethod
     def read_toml_data(cls, data):
-        """Read and parse data stored in a .toml file.
+        """Read and parse data stored in a .toml or .json file.
 
         The data passed to this method needs to be according to the
-        format saved in the .toml file by the .save() method.
+        format saved by the .save() method.
 
         Parameters
         ----------
         data : dict
-            Dictionary obtained from toml.load().
+            Dictionary obtained from toml.load() or json.load().
 
         Returns
         -------
@@ -91,7 +92,7 @@ class Element(ABC):
 
     @classmethod
     def load(cls, file):
-        data = toml.load(file)
+        data = load_data(file)
         # extract single dictionary in the data
         data = list(data.values())[0]
         return cls.read_toml_data(data)

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import toml
 from methodtools import lru_cache
 from plotly import express as px
 from plotly import graph_objects as go
@@ -4128,11 +4127,12 @@ class Rotor(object):
         sio.savemat(file, dic)
 
     def save(self, file):
-        """Save the rotor to a .toml file.
+        """Save the rotor to a .toml or .json file.
 
         Parameters
         ----------
         file : str or pathlib.Path
+            The format is determined by the file extension (.toml or .json).
 
         Examples
         --------
@@ -4143,19 +4143,20 @@ class Rotor(object):
         >>> rotor = rotor_example()
         >>> rotor.save(file)
         """
-        with open(file, "w") as f:
-            toml.dump({"parameters": self.parameters}, f)
+        from ross.utils import dump_data
+
+        dump_data({"parameters": self.parameters}, file)
         for el in self.elements:
             el.save(file)
 
     @classmethod
     def load(cls, file):
-        """Load rotor from toml file.
+        """Load rotor from a .toml or .json file.
 
         Parameters
         ----------
         file : str or pathlib.Path
-            String or Path for a .toml file.
+            String or Path for a .toml or .json file.
 
         Returns
         -------
@@ -4173,7 +4174,9 @@ class Rotor(object):
         >>> rotor1 == rotor2
         True
         """
-        data = toml.load(file)
+        from ross.utils import load_data
+
+        data = load_data(file)
         parameters = data["parameters"]
 
         elements = []

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -7,7 +7,6 @@ shaft.
 import inspect
 
 import numpy as np
-import toml
 from plotly import graph_objects as go
 
 from ross.element import Element
@@ -406,6 +405,8 @@ class ShaftElement(Element):
         return hash(self.tag)
 
     def save(self, file):
+        from ross.utils import load_data, dump_data
+
         signature = inspect.signature(self.__init__)
         args_list = list(signature.parameters)
         args = {arg: getattr(self, arg) for arg in args_list}
@@ -421,13 +422,12 @@ class ShaftElement(Element):
         }
 
         try:
-            data = toml.load(file)
+            data = load_data(file)
         except FileNotFoundError:
             data = {}
 
         data[f"{self.__class__.__name__}_{self.tag}"] = args
-        with open(file, "w") as f:
-            toml.dump(data, f)
+        dump_data(data, file)
 
     @classmethod
     def read_toml_data(cls, data):

--- a/ross/tests/test_bearing_seal_element.py
+++ b/ross/tests/test_bearing_seal_element.py
@@ -561,6 +561,28 @@ def test_save_load(bearing0, bearing_constant, bearing_6dof, magnetic_bearing):
     assert magnetic_bearing == magnetic_bearing_loaded
 
 
+def test_save_load_json(bearing0, bearing_constant, bearing_6dof, magnetic_bearing):
+    file = Path(tempdir) / "bearing0.json"
+    bearing0.save(file)
+    bearing0_loaded = BearingElement.load(file)
+    assert bearing0 == bearing0_loaded
+
+    file = Path(tempdir) / "bearing_constant.json"
+    bearing_constant.save(file)
+    bearing_constant_loaded = BearingElement.load(file)
+    assert bearing_constant == bearing_constant_loaded
+
+    file = Path(tempdir) / "bearing_6dof.json"
+    bearing_6dof.save(file)
+    bearing_6dof_loaded = BearingElement.load(file)
+    assert bearing_6dof == bearing_6dof_loaded
+
+    file = Path(tempdir) / "magnetic_bearing.json"
+    magnetic_bearing.save(file)
+    magnetic_bearing_loaded = MagneticBearingElement.load(file)
+    assert magnetic_bearing == magnetic_bearing_loaded
+
+
 def test_bearing_fluid_flow():
     nz = 30
     ntheta = 20

--- a/ross/tests/test_disk_element.py
+++ b/ross/tests/test_disk_element.py
@@ -68,6 +68,13 @@ def test_save_load(disk):
     assert disk == disk_loaded
 
 
+def test_save_load_json(disk):
+    file = Path(tempdir) / "disk.json"
+    disk.save(file)
+    disk_loaded = DiskElement.load(file)
+    assert disk == disk_loaded
+
+
 def test_disk_equality(disk_from_geometry, disk):
     assert disk != disk_from_geometry
 

--- a/ross/tests/test_point_mass.py
+++ b/ross/tests/test_point_mass.py
@@ -49,3 +49,12 @@ def test_save_load():
     p_loaded = p.load(file)
 
     assert p == p_loaded
+
+
+def test_save_load_json():
+    p = PointMass(n=0, m=10.0, tag="pointmass")
+    file = Path(tempdir) / "point_mass.json"
+    p.save(file)
+    p_loaded = p.load(file)
+
+    assert p == p_loaded

--- a/ross/tests/test_results.py
+++ b/ross/tests/test_results.py
@@ -176,6 +176,36 @@ def test_save_load_sensitivity(rotor_amb):
     assert compare_results[0]
 
 
+def test_save_load_campbell_json(rotor1):
+    speed = np.linspace(0, 1000, 51)
+    response = rotor1.run_campbell(speed)
+
+    file = Path(tempdir) / "campbell.json"
+    response.save(file)
+    response2 = CampbellResults.load(file)
+
+    assert response2.speed_range.all() == response.speed_range.all()
+    assert response2.wd.all() == response.wd.all()
+    assert response2.log_dec.all() == response.log_dec.all()
+    assert response2.whirl_values.all() == response.whirl_values.all()
+
+
+def test_save_load_unbalance_response_json(rotor1):
+    speed = np.linspace(0, 1000, 51)
+    response = rotor1.run_unbalance_response(3, 0.01, 0.0, speed)
+
+    file = Path(tempdir) / "unbalance.json"
+    response.save(file)
+    response2 = ForcedResponseResults.load(file)
+
+    assert response2.rotor == response.rotor
+    assert response2.forced_resp.all() == response.forced_resp.all()
+    assert response2.speed_range.all() == response.speed_range.all()
+    assert response2.velc_resp.all() == response.velc_resp.all()
+    assert response2.accl_resp.all() == response.accl_resp.all()
+    assert response2.unbalance.all() == response.unbalance.all()
+
+
 def test_campbell_plot(rotor1):
     speed = np.linspace(0, 400, 101)
     camp = rotor1.run_campbell(speed)

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -2378,6 +2378,14 @@ def test_save_load(rotor8):
     assert rotor8 == rotor8_loaded
 
 
+def test_save_load_json(rotor8):
+    file = Path(tempdir) / "rotor8.json"
+    rotor8.save(file)
+    rotor8_loaded = Rotor.load(file)
+
+    assert rotor8 == rotor8_loaded
+
+
 def test_plot_rotor(rotor8):
     fig = rotor8.plot_rotor()
 

--- a/ross/tests/test_shaft_element.py
+++ b/ross/tests/test_shaft_element.py
@@ -515,6 +515,18 @@ def test_save_load(tim, tap_tim):
     assert tap_tim == tap_tim_loaded
 
 
+def test_save_load_json(tim, tap_tim):
+    file = Path(tempdir) / "tim.json"
+    tim.save(file)
+    tim_loaded = ShaftElement.load(file)
+    assert tim == tim_loaded
+
+    file = Path(tempdir) / "tap_tim.json"
+    tap_tim.save(file)
+    tap_tim_loaded = ShaftElement.load(file)
+    assert tap_tim == tap_tim_loaded
+
+
 @pytest.fixture
 def tim_6dof():
     #  Timoshenko element
@@ -754,6 +766,13 @@ def test_pickle_coupling(coupling):
 
 def test_save_load_coupling(coupling):
     file = Path(tempdir) / "coupling.toml"
+    coupling.save(file)
+    coupling_loaded = CouplingElement.load(file)
+    assert coupling == coupling_loaded
+
+
+def test_save_load_coupling_json(coupling):
+    file = Path(tempdir) / "coupling.json"
     coupling.save(file)
     coupling_loaded = CouplingElement.load(file)
     assert coupling == coupling_loaded


### PR DESCRIPTION
## Summary
- Add format-aware I/O helpers (`load_data`, `dump_data`, `dump_data_numpy`) to `ross/utils.py` that detect file format from the extension (`.toml` or `.json`)
- Replace direct `toml.load`/`toml.dump` calls across all element, rotor, and results save/load methods with the new helpers
- Add `NumpyEncoder` for JSON serialization of numpy types, with graceful handling of non-serializable objects

## Test plan
- [x] All existing TOML save/load tests pass (no regressions)
- [x] New JSON round-trip tests added for: DiskElement, ShaftElement, CouplingElement, BearingElement, PointMass, Rotor, CampbellResults, ForcedResponseResults
- [ ] Verify CI passes