### PR TITLE
Fix `run_level1()` cross-coupling element instantiation

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3430,7 +3430,7 @@ class Rotor(object):
 
         for i, Q in enumerate(stiffness):
             bearings = [copy(b) for b in self.bearing_elements]
-            cross_coupling = bearings[0].__class__(n=n, kxx=0, cxx=0, kxy=Q, kyx=-Q)
+            cross_coupling = BearingElement(n=n, kxx=0, cxx=0, kxy=Q, kyx=-Q)
             bearings.append(cross_coupling)
 
             rotor = self.__class__(self.shaft_elements, self.disk_elements, bearings)


### PR DESCRIPTION
### Description

When calling `.run_level1()` with bearing classes other than `BearingElement`, an internal constructor error was raised. The root cause was the use of `bearings[0].__class__(...)` to instantiate the cross-coupling element, which assumes that all bearing subclasses share the same constructor signature as `BearingElement`.

This is consistent with the issue previously fixed in #1263 for `run_static()`.

### Root Cause

In `run_level1()`, the cross-coupling element was created as follows:

```python
cross_coupling = bearings[0].__class__(
    n=n,
    kxx=0,
    cxx=0,
    kxy=Q,
    kyx=-Q,
)
```

This pattern fails for bearing subclasses that have different constructor signatures. Furthermore, it is semantically incorrect: the cross-coupling element used in the API 684 Level 1 stability analysis is a purely mathematical representation of the destabilizing stiffness terms (`kxy = Q`, `kyx = -Q`). It is not meant to reproduce the physical bearing model — the original bearing elements are already preserved via `copy()`.

### Fix

Replaced `bearings[0].__class__(...)` with `BearingElement(...)`, which is the appropriate base class for this mathematical element and is consistent with the fix previously applied in `run_static()`.

```python
cross_coupling = BearingElement(
    n=n,
    kxx=0,
    cxx=0,
    kxy=Q,
    kyx=-Q,
)
```

### Related Issues

Closes #1300
See also: #1263