### PR TITLE
ROSS GPT URL update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Key sections:
 
 ## 🤖 ROSS GPT
 
-Meet [**ROSS GPT**](https://bit.ly/rossgpt), the official AI assistant for the ROSS package. With ROSS GPT, you can:
+Meet [**ROSS GPT**](https://chatgpt.com/g/g-6a0776b675588191a111daf172ecfcfe-ross-gpt-2-0), the official AI assistant for the ROSS package. With ROSS GPT, you can:
 - Create and modify rotor models using ROSS in Python.
 - Request practical examples for modal analysis, Campbell diagrams, unbalance response, and more.
 - Get detailed technical explanations on elements such as shafts, disks, bearings, and couplings.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -29,10 +29,10 @@ pip install git+https://github.com/petrobras/ross.git
 
 Need help building your rotor model or running an analysis?
 
-Meet [**ROSS GPT**](https://bit.ly/rossgpt), a virtual assistant trained specifically for the ROSS package. You can:
+Meet [**ROSS GPT**](https://chatgpt.com/g/g-6a0776b675588191a111daf172ecfcfe-ross-gpt-2-0), a virtual assistant trained specifically for the ROSS package. You can:
 
 - Generate rotor models in Python with just a description.
 - Run and interpret modal analysis, Campbell diagrams, and more.
 - Understand technical aspects of ROSS elements like ShaftElement, DiskElement, BearingElement, etc.
 
-👉 [Click here to start using ROSS GPT](https://bit.ly/rossgpt).
+👉 [Click here to start using ROSS GPT](https://chatgpt.com/g/g-6a0776b675588191a111daf172ecfcfe-ross-gpt-2-0).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ The source code is available at [github](https://github.com/petrobras/ross).
 
 ### 💡 ROSS GPT – Your Virtual Assistant for Rotordynamics
 
-Access [ROSS GPT](https://bit.ly/rossgpt), a virtual assistant specialized in the ROSS (Rotordynamic Open-Source Software) package. 
+Access [ROSS GPT](https://chatgpt.com/g/g-6a0776b675588191a111daf172ecfcfe-ross-gpt-2-0), a virtual assistant specialized in the ROSS (Rotordynamic Open-Source Software) package. 
 
 ::::{grid} 2
 :gutter: 2


### PR DESCRIPTION
Documentation update to include the new ROSS GPT URL ([**ROSS GPT 2.0**](https://chatgpt.com/g/g-6a0776b675588191a111daf172ecfcfe-ross-gpt-2-0)).