### PR TITLE
Update documentation

### DIFF
--- a/ross/bearings/plain_journal.py
+++ b/ross/bearings/plain_journal.py
@@ -73,6 +73,15 @@ class PlainJournal(BearingElement):
     Describes the operation conditions of the bearing.
     frequency : list, pint.Quantity
         Array with the frequencies (rad/s).
+    sommerfeld_type : int
+        Choose the method to calculate the sommerfeld number. Options are:
+        - 1 : Uses the classical Sommerfeld formulation bsed on:
+            - viscosity
+            - geometry
+            - shaft speed
+            - externally applied load (fxs_load, fys_load)
+        - 2 (default): Uses a force-based normalized formulation 
+        based on the calculated hydrodynamic reaction forces.
     fxs_load : float, pint.Quantity
         Load in X direction. The unit is Newton.
     fys_load : float, pint.Quantity

--- a/ross/bearings/plain_journal.py
+++ b/ross/bearings/plain_journal.py
@@ -80,7 +80,7 @@ class PlainJournal(BearingElement):
             - geometry
             - shaft speed
             - externally applied load (fxs_load, fys_load)
-        - 2 (default): Uses a force-based normalized formulation 
+        - 2 (default): Uses a force-based normalized formulation
         based on the calculated hydrodynamic reaction forces.
     fxs_load : float, pint.Quantity
         Load in X direction. The unit is Newton.

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3172,6 +3172,7 @@ class Rotor(object):
 
         return results
 
+    @check_units
     def run_ucs(
         self,
         stiffness_range=None,


### PR DESCRIPTION
- Added a `sommerfeld_type `entry to the `PlainJournal `
    Parameters section in `ross/bearings/plain_journal.py`.

- Documented the two supported options:
  - `1`: classical Sommerfeld formulation using viscosity, geometry, shaft speed, and externally applied loads (`fxs_load`, `fys_load`).
  - `2` (default): force-based normalized formulation using the calculated hydrodynamic reaction forces.

- Added the `@check_units` decorator to `Rotor.run_ucs()` in` ross/rotor_assembly.py`.