### PR TITLE
Create add_elements method

### DIFF
--- a/ross/element.py
+++ b/ross/element.py
@@ -123,6 +123,24 @@ class Element(ABC):
             subclasses.extend(subclass.get_subclasses())
         return subclasses
 
+    @classmethod
+    def get_base_class(cls):
+        """Get the direct subclass of Element in the inheritance chain.
+
+        Returns the first class in the inheritance hierarchy that directly
+        inherits from Element. This is useful for identifying the base element
+        type when working with subclasses or indirect subclasses.
+
+        Returns
+        -------
+        base_class : type
+            The direct subclass of Element in the inheritance chain.
+        """
+        base_class = cls
+        while base_class.__base__ != Element:
+            base_class = base_class.__base__
+        return base_class
+
     @abstractmethod
     def M(self):
         """Mass matrix.

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -857,6 +857,59 @@ class Rotor(object):
             tag=self.tag,
         )
 
+    def add_elements(self, new_elements):
+        """Add elements to rotor.
+
+        This method returns the modified rotor with additional elements.
+        This is not valid for shaft elements.
+
+        Parameters
+        ----------
+        new_elements : list
+            List with the new elements. It may be disks, gears, bearings,
+            seals and point masses.
+
+        Returns
+        -------
+        A rotor object.
+
+        Examples
+        --------
+        >>> import ross as rs
+        >>> rotor = rs.rotor_example()
+        >>> seal = rs.SealElement(n=3, kxx=1e6, kyy=0.8e6, cxx=2e2, cyy=1.5e2)
+        >>> disk = rs.DiskElement(n=5, m=32, Id=0.2, Ip=0.3)
+        >>> new_rotor = rotor.add_elements([seal, disk])
+        >>> len(new_rotor.elements)
+        12
+        """
+
+        shaft_elements = deepcopy(self.shaft_elements)
+        disk_elements = deepcopy(self.disk_elements)
+        bearing_elements = deepcopy(self.bearing_elements)
+        point_mass_elements = deepcopy(self.point_mass_elements)
+
+        for el in new_elements:
+            main_class = el.__class__.get_base_class()
+
+            if main_class == DiskElement:
+                disk_elements.append(el)
+            elif main_class == BearingElement:
+                bearing_elements.append(el)
+            elif main_class == PointMass:
+                point_mass_elements.append(el)
+
+        return Rotor(
+            shaft_elements,
+            disk_elements=disk_elements,
+            bearing_elements=bearing_elements,
+            point_mass_elements=point_mass_elements,
+            min_w=self.min_w,
+            max_w=self.max_w,
+            rated_w=self.rated_w,
+            tag=self.tag,
+        )
+
     @lru_cache()
     @check_units
     def run_modal(self, speed, num_modes=12, sparse=True, synchronous=False):


### PR DESCRIPTION
Adds a new `add_elements()` method to the `Rotor` class that enables users to conveniently add multiple elements (disks, bearings, seals, point masses) to an existing rotor without manually reconstructing the entire rotor object.

## New Features
- **`Rotor.add_elements(new_elements)`**: Accepts a list of new elements and returns a modified rotor with those elements integrated. Supports:
  - Disk elements
  - Bearing elements  
  - Seal elements
  - Point mass elements
  
- **`Element.get_base_class()`**: Helper method that identifies the direct `Element` subclass in the inheritance chain, enabling proper element classification and routing.

## Example Usage

```python
import ross as rs

rotor = rs.rotor_example()

seal = rs.SealElement(n=3, kxx=1e6, kyy=0.8e6, cxx=2e2, cyy=1.5e2)
disk = rs.DiskElement(n=5, m=32, Id=0.2, Ip=0.3)

new_rotor = rotor.add_elements([seal, disk])
```

### > rotor:
<img width="959" height="525" alt="1" src="https://github.com/user-attachments/assets/ca038ffa-e410-4daa-8911-725f80996ed1" />

### > new_rotor:
<img width="959" height="525" alt="2" src="https://github.com/user-attachments/assets/57c791bb-cf95-45f6-a5a9-9f752c435566" />
