### PR TITLE
Fix `LabyrinthSeal` incorrect coefficients when computing multiple frequencies in the same instance

### DIFF
--- a/ross/seals/labyrinth_seal.py
+++ b/ross/seals/labyrinth_seal.py
@@ -322,11 +322,9 @@ class LabyrinthSeal(SealElement):
             ) ** 0.5
 
     def _reset_perturbation_arrays(self):
-        """Clear arrays filled incrementally in zvel/zvel_jen and pert.
-
-        Without this reset, coefficients from a previous ``run(frequency)``
-        call can leak into the next speed when multiple frequencies are
-        computed on the same instance.
+        """Reset perturbation and velocity-coupling workspace arrays.
+        Zeros ``gm``, ``rhs``, ``cg``, ``cx``, ``taur``, and ``taus`` before
+        each base-flow and perturbation solve in ``setup()``.
         """
         self.gm.fill(0)
         self.rhs.fill(0)

--- a/ross/seals/labyrinth_seal.py
+++ b/ross/seals/labyrinth_seal.py
@@ -268,8 +268,10 @@ class LabyrinthSeal(SealElement):
             coefficients_dict = {
                 c: [k[c] for k in results]
                 for c in results[0].keys()
-                if c not in ["pressure"]
+                if c not in ["pressure", "pert_rcond", "pert_condition_number"]
             }
+            self.pert_rcond = [r["pert_rcond"] for r in results]
+            self.pert_condition_number = [r["pert_condition_number"] for r in results]
 
         super().__init__(
             self.n,
@@ -319,6 +321,20 @@ class LabyrinthSeal(SealElement):
                 (1 - self.pg**2) / (self.n_teeth - np.log(self.pg))
             ) ** 0.5
 
+    def _reset_perturbation_arrays(self):
+        """Clear arrays filled incrementally in zvel/zvel_jen and pert.
+
+        Without this reset, coefficients from a previous ``run(frequency)``
+        call can leak into the next speed when multiple frequencies are
+        computed on the same instance.
+        """
+        self.gm.fill(0)
+        self.rhs.fill(0)
+        self.cg.fill(0)
+        self.cx.fill(0)
+        self.taur.fill(0)
+        self.taus.fill(0)
+
     def setup(self):
         self.epslon = 0.6
         self.awrl = self.epslon * self.radial_clearance[0]
@@ -326,8 +342,7 @@ class LabyrinthSeal(SealElement):
         self.nc = self.n_teeth - 1
         self.np = self.n_teeth + 1
 
-        # Arrays already initialized with np.full() in __init__
-        # No need to re-assign values that are already set
+        self._reset_perturbation_arrays()
 
         self.ndof = 8 * self.nc
         self.nbw = 33
@@ -1164,6 +1179,8 @@ class LabyrinthSeal(SealElement):
             rhs2[i] = self.rhs[i][1]
         cnd = cond(A)
         rcond = 1 / cnd
+        self.pert_condition_number = cnd
+        self.pert_rcond = rcond
 
         if rcond <= 1 / 3.0e8:
             warn("Almost singular matrix. \n No prediction for dynamic coefficients.")
@@ -1254,6 +1271,8 @@ class LabyrinthSeal(SealElement):
             "pressure": "p",
         }
         coefficients_dict = {k: getattr(self, v) for k, v in attrbute_coef.items()}
+        coefficients_dict["pert_rcond"] = self.pert_rcond
+        coefficients_dict["pert_condition_number"] = self.pert_condition_number
 
         return coefficients_dict
 


### PR DESCRIPTION
### Description

When using `frequency=Q_([2000, 3000, 5000], "RPM")`, dynamic coefficients at intermediate and final speeds may differ from those obtained with one RPM per instance. The same applies to `HybridSeal`, which creates the labyrinth with the full `frequency` vector internally.

### Root cause

In `run()`, each speed calls `setup() → zpres() → zvel() → pert()`. The arrays `gm`, `rhs`, `cg`, `cx`, `taur`, and `taus` are filled incrementally but never reset between frequencies. `pert()` only writes to specific positions of the banded matrix, so the remainder retains values from the previous RPM. The first frequency is unaffected; subsequent ones carry over leftover state.

### Fix

Zero out `gm`, `rhs`, `cg`, `cx`, `taur`, and `taus` in `setup()` before each frequency run.

### Regression test

Compare coefficients (`kxx`, `cxx`, `kxy`, …) between a multi-frequency instance and separate single-RPM instances with the same parameters. Results should match.

```python
seal     = LabyrinthSeal(..., frequency=Q_([2000, 3000, 5000], "RPM"))
seal_3k  = LabyrinthSeal(..., frequency=Q_([3000], "RPM"))
# seal.kxx[1] == seal_3k.kxx[0]
```

### Affected

`LabyrinthSeal` (multi-frequency), `HybridSeal`, and any output that depends on interpolated coefficients (`format_table`, `plot`).

---

Closes petrobras/ross#1312