### PR TITLE
Remove analz option from LabyrinthSeal; always compute coefficients

### DIFF
--- a/ross/seals/hybrid_seal.py
+++ b/ross/seals/hybrid_seal.py
@@ -135,11 +135,6 @@ class HybridSeal(SealElement):
             Dynamic viscosity at states: [mu_state1, mu_state2] (kg/(m·s)).
             Required if gas_composition is None.
             Default is None.
-        - analz : str, optional
-            Indicates what will be analysed.
-            Specify "FULL" for rotordynamic calculation and leakage analysis.
-            Specify "LEAKAGE" for leakage analysis only.
-            Default is "FULL".
         - nprt : int, optional
             Number of parameters to be printed in the output: 1 maximum, 5 minimum.
             Default is 1.

--- a/ross/seals/labyrinth_seal.py
+++ b/ross/seals/labyrinth_seal.py
@@ -109,11 +109,6 @@ class LabyrinthSeal(SealElement):
         Dynamic viscosity at states: [mu_state1, mu_state2] (kg/(m·s)).
         Required if gas_composition is None.
         Default is None.
-    analz : str, optional
-        Indicates what will be analysed.
-        Specify "FULL" for rotordynamic calculation and leakage analysis.
-        Specify "LEAKAGE" for leakage analysis only.
-        Default is "FULL".
     nprt : int, optional
         Number of parameters to be printed in the output: 1 maximum, 5 minimum.
         Default is 1.
@@ -183,7 +178,6 @@ class LabyrinthSeal(SealElement):
         gamma=None,
         tz=None,
         muz=None,
-        analz="FULL",
         nprt=1,
         iopt1=0,
         print_results=False,
@@ -253,7 +247,6 @@ class LabyrinthSeal(SealElement):
         self.tooth_width = tooth_width
         self.seal_type = seal_type
 
-        self.analz = analz
         self.nprt = nprt
         self.iopt1 = iopt1
 
@@ -1311,8 +1304,7 @@ class LabyrinthSeal(SealElement):
             self.zvel()
         elif self.iopt1 == 1:
             self.zvel_jen()
-        if self.analz != "LEAKAGE":
-            self.pert()
+        self.pert()
 
         attrbute_coef = {
             "kxx": "kxx",

--- a/ross/tests/test_labyrinth.py
+++ b/ross/tests/test_labyrinth.py
@@ -289,6 +289,24 @@ def test_labyrinth_coefficients(labyrinth):
     assert_allclose(labyrinth.cyy, 23.825111, rtol=1e-4)
 
 
+def test_labyrinth_always_computes_coefficients(labyrinth_manual):
+    """The seal always computes rotordynamic coefficients.
+
+    The removed ``analz="LEAKAGE"`` option used to skip ``pert()`` and then
+    crash while assembling the (never created) coefficient attributes. There is
+    no longer a leakage-only mode: stiffness, damping and leakage are always
+    available after construction.
+    """
+    import inspect
+
+    assert "analz" not in inspect.signature(LabyrinthSeal.__init__).parameters
+
+    for coef in ("kxx", "kyy", "kxy", "kyx", "cxx", "cyy", "cxy", "cyx"):
+        value = getattr(labyrinth_manual, coef)
+        assert np.all(np.isfinite(value))
+    assert np.all(np.isfinite(labyrinth_manual.seal_leakage))
+
+
 # Real-gas (gas_model) tests --------------------------------------------------
 
 # Dense-gas case (Z well below 1) used for the directional real-gas check.


### PR DESCRIPTION
## Summary

The `analz` parameter of `LabyrinthSeal` is removed. Rotordynamic coefficients (and leakage) are now always computed.

## Motivation

The documented `analz="LEAKAGE"` mode was broken. In `run()`, `pert()` was correctly skipped for `LEAKAGE`, but the method then unconditionally assembled its return dictionary from the stiffness/damping attributes (`kxx`, `kxy`, …) that **only `pert()` creates**:

```python
if self.analz != "LEAKAGE":
    self.pert()
...
coefficients_dict = {k: getattr(self, v) for k, v in attrbute_coef.items()}  # reads self.kxx
```

So constructing with `analz="LEAKAGE"` raised `AttributeError: 'LabyrinthSeal' object has no attribute 'kxx'`, and because `run()` is called from `__init__`, construction failed entirely. A leakage-only mode would also need defaults for the base class's required `kxx`/`cxx` arguments.

Rather than repair a rarely-needed shortcut, this removes the option so the seal has a single, well-defined behavior.

## Changes

- Remove the `analz` parameter, its attribute assignment, and its docstring entry from `LabyrinthSeal`.
- `pert()` is now always called in `run()`.
- Remove the stale `analz` mention from `HybridSeal`'s docstring.
- Add a regression test asserting `analz` is no longer a constructor parameter and that all coefficients and leakage are finite after construction.

## Testing

- `pytest ross/tests/test_labyrinth.py` — 18 passed.
- `ruff check` / `ruff format --check` — clean.