### PR TITLE
Fix LabyrinthSeal seal_leakage units (kg/s) and HybridSeal mass-flow balance

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -1419,7 +1419,7 @@ class SealElement(BearingElement):
         Direct mass in the z direction (kg).
         Default is 0.
     seal_leakage : float, optional
-        Seal leakage.
+        Seal leakage mass flow rate (kg/s).
     frequency : array, pint.Quantity, optional
         Array with the frequencies (rad/s).
     tag : str, optional

--- a/ross/seals/holepattern_seal.py
+++ b/ross/seals/holepattern_seal.py
@@ -546,16 +546,17 @@ class HolePatternSeal(SealElement):
                 + (1.0 - self.rlx_factor) * p2
             )
             p2_old, delp_old = temp_p, temp_delp
-            while True:
+            for _ in range(60):
                 self.mdot, self.mz2[0], self.t[0], self.mt[0] = self.inlet_loss(p2)
                 ichoke = self._integrate_base_state()
                 if not ichoke:
                     p5, _, _ = self.exit_loss(self.mz2[self.nz], self.t[self.nz])
                     delp = p5 - self.outlet_pressure
-                    if delp >= 0:
-                        break
+                    break
                 iglobalchoke = 1
                 p2 = p2_old + 0.5 * (p2 - p2_old)
+            else:
+                return None
             if (
                 abs(delp)
                 < self.tolerance * (self.inlet_pressure - self.outlet_pressure)

--- a/ross/seals/hybrid_seal.py
+++ b/ross/seals/hybrid_seal.py
@@ -149,7 +149,7 @@ class HybridSeal(SealElement):
     tolerance : float, optional
         Tolerance for pressure matching. Default is 1e-6.
     max_iterations : int, optional
-        Maximum iterations for pressure matching. Default is 1e20.
+        Maximum iterations for pressure matching. Default is 100.
     color : str, optional
         Color for element visualization. Default is "#787FF6".
     scale_factor : float, optional
@@ -200,7 +200,7 @@ class HybridSeal(SealElement):
     ...   labyrinth_parameters=laby_params,
     ... )
     >>> hybrid.seal_leakage  # doctest: +ELLIPSIS
-    0.0348...
+    0.0128...
     """
 
     @check_units
@@ -218,7 +218,7 @@ class HybridSeal(SealElement):
         molar=None,
         gamma=None,
         tolerance=1e-6,
-        max_iterations=1e20,
+        max_iterations=100,
         color="#787FF6",
         scale_factor=0.75,
         **kwargs,
@@ -265,7 +265,8 @@ class HybridSeal(SealElement):
             hole_leakage = holep.seal_leakage[0]
             laby_leakage = laby.seal_leakage[0]
 
-            convergence_leakage = abs(laby_leakage - hole_leakage) / hole_leakage
+            if hole_leakage > 0:
+                convergence_leakage = abs(laby_leakage - hole_leakage) / hole_leakage
 
             if hole_leakage > laby_leakage:
                 p_low = interface_pressure

--- a/ross/seals/labyrinth_seal.py
+++ b/ross/seals/labyrinth_seal.py
@@ -1315,10 +1315,12 @@ class LabyrinthSeal(SealElement):
             "cyy": "cxx",
             "cxy": "cxy",
             "cyx": "cyx",
-            "seal_leakage": "mdot",
             "pressure": "p",
         }
         coefficients_dict = {k: getattr(self, v) for k, v in attrbute_coef.items()}
+        coefficients_dict["seal_leakage"] = (
+            self.mdot * 2 * np.pi * (self.shaft_radius + 0.5 * self.radial_clearance[0])
+        )
         coefficients_dict["pert_rcond"] = self.pert_rcond
         coefficients_dict["pert_condition_number"] = self.pert_condition_number
 

--- a/ross/tests/test_hybrid_seal.py
+++ b/ross/tests/test_hybrid_seal.py
@@ -85,7 +85,7 @@ def test_hybrid_interface_pressure(hybrid_seal):
     assert hybrid_seal.interface_pressure > COMMON_PARAMS["outlet_pressure"]
     assert hybrid_seal.interface_pressure < COMMON_PARAMS["inlet_pressure"]
 
-    assert_allclose(hybrid_seal.interface_pressure, 219522.094727, rtol=1e-2)
+    assert_allclose(hybrid_seal.interface_pressure, 473920.917511, rtol=1e-2)
 
 
 def test_hybrid_leakage_matching(hybrid_seal):
@@ -95,7 +95,7 @@ def test_hybrid_leakage_matching(hybrid_seal):
     hybrid_leakage = hybrid_seal.seal_leakage
 
     assert_allclose(laby_leakage, hole_leakage, rtol=1e-5)
-    assert_allclose(hybrid_leakage, 0.034898, rtol=1e-2)
+    assert_allclose(hybrid_leakage, 0.012881, rtol=1e-2)
 
 
 def test_hybrid_coefficients_combination(hybrid_seal):
@@ -104,27 +104,27 @@ def test_hybrid_coefficients_combination(hybrid_seal):
     hole_kxx = hybrid_seal.hole_pattern.kxx[0]
     hybrid_kxx = hybrid_seal.kxx[0]
     assert_allclose(hybrid_kxx, laby_kxx + hole_kxx, rtol=1e-6)
-    assert_allclose(hybrid_kxx, 202947.350538, rtol=1e-2)
+    assert_allclose(hybrid_kxx, -77662.823937, rtol=1e-2)
 
     laby_kxy = hybrid_seal.laby.kxy[0]
     hole_kxy = hybrid_seal.hole_pattern.kxy[0]
     hybrid_kxy = hybrid_seal.kxy[0]
     assert_allclose(hybrid_kxy, laby_kxy + hole_kxy, rtol=1e-6)
-    assert_allclose(hybrid_kxy, 28599.34387089, rtol=1e-2)
+    assert_allclose(hybrid_kxy, -48746.515901, rtol=1e-2)
 
     # Check direct damping
     laby_cxx = hybrid_seal.laby.cxx[0]
     hole_cxx = hybrid_seal.hole_pattern.cxx[0]
     hybrid_cxx = hybrid_seal.cxx[0]
     assert_allclose(hybrid_cxx, laby_cxx + hole_cxx, rtol=1e-6)
-    assert_allclose(hybrid_cxx, 61.950937, rtol=1e-2)
+    assert_allclose(hybrid_cxx, -113.720815, rtol=1e-2)
 
     # Check cross-coupled damping
     laby_cxy = hybrid_seal.laby.cxy[0]
     hole_cxy = hybrid_seal.hole_pattern.cxy[0]
     hybrid_cxy = hybrid_seal.cxy[0]
     assert_allclose(hybrid_cxy, laby_cxy + hole_cxy, rtol=1e-6)
-    assert_allclose(hybrid_cxy, -7.383646, rtol=1e-2)
+    assert_allclose(hybrid_cxy, -26.744431, rtol=1e-2)
 
 
 @pytest.fixture
@@ -144,7 +144,7 @@ def test_hybrid_gc_interface_pressure(hybrid_seal_gc):
     assert hybrid_seal_gc.interface_pressure > COMMON_PARAMS["outlet_pressure"]
     assert hybrid_seal_gc.interface_pressure < COMMON_PARAMS["inlet_pressure"]
 
-    assert_allclose(hybrid_seal_gc.interface_pressure, 219462.966919, rtol=1e-2)
+    assert_allclose(hybrid_seal_gc.interface_pressure, 473830.795288, rtol=1e-2)
 
 
 def test_hybrid_gc_leakage_matching(hybrid_seal_gc):
@@ -154,7 +154,7 @@ def test_hybrid_gc_leakage_matching(hybrid_seal_gc):
     hybrid_leakage = hybrid_seal_gc.seal_leakage
 
     assert_allclose(laby_leakage, hole_leakage, rtol=1e-5)
-    assert_allclose(hybrid_leakage, 0.034886, rtol=1e-2)
+    assert_allclose(hybrid_leakage, 0.012895, rtol=1e-2)
 
 
 def test_hybrid_gc_coefficients_combination(hybrid_seal_gc):
@@ -163,24 +163,24 @@ def test_hybrid_gc_coefficients_combination(hybrid_seal_gc):
     hole_kxx = hybrid_seal_gc.hole_pattern.kxx[0]
     hybrid_kxx = hybrid_seal_gc.kxx[0]
     assert_allclose(hybrid_kxx, laby_kxx + hole_kxx, rtol=1e-6)
-    assert_allclose(hybrid_kxx, 204847.369174, rtol=1e-2)
+    assert_allclose(hybrid_kxx, -78044.786468, rtol=1e-2)
 
     laby_kxy = hybrid_seal_gc.laby.kxy[0]
     hole_kxy = hybrid_seal_gc.hole_pattern.kxy[0]
     hybrid_kxy = hybrid_seal_gc.kxy[0]
     assert_allclose(hybrid_kxy, laby_kxy + hole_kxy, rtol=1e-6)
-    assert_allclose(hybrid_kxy, 28662.88319966, rtol=1e-2)
+    assert_allclose(hybrid_kxy, -48797.395120, rtol=1e-2)
 
     # Check direct damping
     laby_cxx = hybrid_seal_gc.laby.cxx[0]
     hole_cxx = hybrid_seal_gc.hole_pattern.cxx[0]
     hybrid_cxx = hybrid_seal_gc.cxx[0]
     assert_allclose(hybrid_cxx, laby_cxx + hole_cxx, rtol=1e-6)
-    assert_allclose(hybrid_cxx, 62.08197, rtol=1e-2)
+    assert_allclose(hybrid_cxx, -113.855070, rtol=1e-2)
 
     # Check cross-coupled damping
     laby_cxy = hybrid_seal_gc.laby.cxy[0]
     hole_cxy = hybrid_seal_gc.hole_pattern.cxy[0]
     hybrid_cxy = hybrid_seal_gc.cxy[0]
     assert_allclose(hybrid_cxy, laby_cxy + hole_cxy, rtol=1e-6)
-    assert_allclose(hybrid_cxy, -7.414197, rtol=1e-2)
+    assert_allclose(hybrid_cxy, -26.686262, rtol=1e-2)

--- a/ross/tests/test_labyrinth.py
+++ b/ross/tests/test_labyrinth.py
@@ -122,7 +122,7 @@ def test_labyrinth_gas_composition_coefficients_range(labyrinth_gas_composition)
     assert_allclose(abs(labyrinth_gas_composition.kxy[0]), 35515, rtol=0.01)  # ±1%
     assert_allclose(labyrinth_gas_composition.cxx[0], 23.8, rtol=0.01)  # ±1%
     assert_allclose(
-        labyrinth_gas_composition.seal_leakage[0], 0.05195, rtol=0.01
+        labyrinth_gas_composition.seal_leakage[0], 0.023714, rtol=0.01
     )  # ±1%
 
 
@@ -161,7 +161,7 @@ def test_labyrinth_refprop_backend():
         # REFPROP expected values (from testing)
         assert_allclose(labyrinth.kxx[0], -50435.21, rtol=1e-3)
         assert_allclose(labyrinth.cxx[0], 23.808, rtol=1e-3)
-        assert_allclose(labyrinth.seal_leakage[0], 0.051951, rtol=1e-3)
+        assert_allclose(labyrinth.seal_leakage[0], 0.023714, rtol=1e-3)
 
         # Check derived properties
         assert_allclose(labyrinth.R, 287.12, rtol=1e-3)
@@ -186,7 +186,7 @@ def test_labyrinth_heos_backend():
         # Note: HEOS values differ slightly from REFPROP (<0.05%)
         assert_allclose(labyrinth.kxx[0], -50449.96, rtol=1e-3)
         assert_allclose(labyrinth.cxx[0], 23.797, rtol=1e-3)
-        assert_allclose(labyrinth.seal_leakage[0], 0.051951, rtol=1e-3)
+        assert_allclose(labyrinth.seal_leakage[0], 0.023714, rtol=1e-3)
 
         # Check derived properties
         assert_allclose(labyrinth.R, 287.12, rtol=1e-3)
@@ -348,7 +348,7 @@ def test_labyrinth_ideal_backend_unchanged(labyrinth_manual):
     assert_allclose(labyrinth_manual.kxy[0], 35541.605311914, rtol=1e-9)
     assert_allclose(labyrinth_manual.cxx[0], 23.82511134106155, rtol=1e-9)
     assert_allclose(labyrinth_manual.cxy[0], 56.255682475614, rtol=1e-9)
-    assert_allclose(labyrinth_manual.seal_leakage[0], 0.051961660704224755, rtol=1e-9)
+    assert_allclose(labyrinth_manual.seal_leakage[0], 0.023719116584285112, rtol=1e-9)
 
 
 def test_labyrinth_real_requires_gas_composition():


### PR DESCRIPTION
## Summary

`LabyrinthSeal.seal_leakage` returned the solver-internal `mdot`, which is leakage **per unit circumferential length** (kg/(m·s)), while `HolePatternSeal` reports **total mass flow** (kg/s). This was unexpected from the user perspective — total leakage required multiplying by `2π(R + c/2)` — and it had a real consequence inside ROSS: `HybridSeal`'s interface-pressure bisection compared the two quantities directly, converging in inconsistent units, so its interface pressure and combined coefficients were not physically consistent.

## Changes

- **`LabyrinthSeal`**: `seal_leakage` now returns total mass flow in kg/s (`mdot × 2π(R + c/2)`), matching the value already printed with `print_results=True`. The internal per-length `mdot` used by the solver is unchanged.
- **`HolePatternSeal`**: fixed an infinite loop in `calculate_leakage` at small pressure drops. The choke-recovery `while True` loop treated a non-choked overshoot (`p5 < outlet_pressure`) as choke and contracted `p2` toward an equally bad previous guess forever. The loop is now bounded, contracts only on actual choke, and hands non-choked overshoot back to the secant iteration, which handles it correctly. Verified the solver now converges smoothly down to ~1% pressure drop; all 13 existing hole-pattern regression tests pass unchanged.
- **`HybridSeal`**: `max_iterations` default `1e20` → `100`, and a failed hole-pattern solve (zero leakage) no longer divides by zero in the convergence check.
- **Tests/docs**: labyrinth leakage expectations converted to kg/s; hybrid reference values regenerated with the corrected physics; `SealElement` docstring and the seal tutorial now state the unit.

## Impact on results

With consistent units, the hybrid balance point for the test geometry moves from a fictitious ~219 kPa to ~474 kPa interface pressure with matched leakage ~0.0129 kg/s — the labyrinth stage takes nearly all the pressure drop, so its destabilizing terms now dominate the combined coefficients (e.g. `kxx` +203 kN/m → −77.7 kN/m). The previous reference values were artifacts of the unit mismatch (the bisection also happened to avoid the hole-pattern low-Δp region where the infinite loop lived, which is why it was never hit before). The new hybrid values are self-generated from the corrected physics and have no external validation yet.

**Breaking change**: any downstream code that post-multiplied `LabyrinthSeal.seal_leakage` by `2π(R + c/2)` must drop that correction.

## Testing

- `pytest ross/tests/test_labyrinth.py ross/tests/test_holepattern.py ross/tests/test_hybrid_seal.py --doctest-modules ross/seals/` — 41 passed (this suite previously hung indefinitely via the hole-pattern infinite loop when run with corrected units).
- `ruff check` / `ruff format` clean on changed files.