### PR TITLE
Redesign plot_rotor

### DIFF
--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -14,6 +14,7 @@ from plotly import graph_objects as go
 from scipy import interpolate as interpolate
 
 from ross.element import Element
+from ross.plotly_theme import color_shades
 from ross.bearings import fluid_flow as flow
 from ross.bearings.fluid_flow_coefficients import (
     calculate_stiffness_and_damping_coefficients,
@@ -50,6 +51,9 @@ class BearingElement(Element):
         Extra instance attributes to persist on save/load, beyond __init__
         parameters and coefficients. Subclasses can extend this to include
         derived quantities that are expensive to recompute.
+    _legend_group : str
+        Name of the legend entry under which the element is drawn in
+        :py:meth:`ross.Rotor.plot_rotor`.
     For speed dependent parameters, each argument should be passed
     as an array and the correspondent speed values should also be
     passed as an array.
@@ -141,6 +145,7 @@ class BearingElement(Element):
     """
 
     _save_attrs = []
+    _legend_group = "Bearing"
 
     @check_units
     def __init__(
@@ -893,11 +898,15 @@ class BearingElement(Element):
         """Bearing element patch.
 
         Patch that will be used to draw the bearing element using Plotly library.
+        The bearing is drawn as a pedestal reaching from the shaft surface to
+        its support, closed by a ground bar when it is not linked to another
+        element.
 
         Parameters
         ----------
         position : tuple
-            Position (z, y_low, y_upp) in which the patch will be drawn.
+            Position (z, y_low, y_upp, y_center) in which the patch will be
+            drawn.
         fig : plotly.graph_objects.Figure
             The figure object which traces are added on.
 
@@ -906,143 +915,76 @@ class BearingElement(Element):
         fig : plotly.graph_objects.Figure
             The figure object which traces are added on.
         """
-        default_values = dict(
-            mode="lines",
-            line=dict(width=1, color=self.color),
-            name=self.tag,
-            legendgroup="bearings",
-            showlegend=False,
-            hoverinfo="none",
-        )
-
-        # geometric factors
         zpos, ypos, ypos_s, yc_pos = position
+        shades = color_shades(self.color)
 
-        icon_h = ypos_s - ypos  # bearing icon height
-        icon_w = icon_h / 2.0  # bearing icon width
-        coils = 6  # number of points to generate spring
-        n = 5  # number of ground lines
-        step = icon_w / (coils + 1)  # spring step
+        icon_h = ypos_s - ypos
+        icon_w = 0.22 * icon_h
 
-        zs0 = zpos - (icon_w / 3.5)
-        zs1 = zpos + (icon_w / 3.5)
-        ys0 = ypos + 0.25 * icon_h
+        x_body = []
+        y_body = []
+        x_ground = []
+        y_ground = []
+        for sign in (1, -1):
+            y0 = sign * ypos + yc_pos
+            y1 = sign * ypos_s + yc_pos
+            y_neck = y0 + sign * 0.16 * icon_h
+            x_body += [zpos, zpos - icon_w, zpos - icon_w, zpos + icon_w, zpos + icon_w]
+            x_body += [zpos, None]
+            y_body += [y0, y_neck, y1, y1, y_neck, y0, None]
+            x_ground += [zpos - 1.3 * icon_w, zpos + 1.3 * icon_w, None]
+            y_ground += [y1, y1, None]
 
-        # plot bottom base
-        x_bot = [zpos, zpos, zs0, zs1]
-        yl_bot = [ypos, ys0, ys0, ys0]
-        yu_bot = [-y for y in yl_bot]
-        fig.add_trace(go.Scatter(x=x_bot, y=np.add(yl_bot, yc_pos), **default_values))
-        fig.add_trace(go.Scatter(x=x_bot, y=np.add(yu_bot, yc_pos), **default_values))
-
-        # Add hover information marker at the center of bottom base
         customdata, hovertemplate = self._hover_info()
-        # Scale marker size proportionally to the bearing icon height
-        # icon_h already includes the scale_factor effect from rotor assembly
-        marker_size = icon_h * 200  # proportional to actual bearing size
-        hover_marker_values_top = dict(
-            mode="markers",
-            x=[zpos],
-            y=[ypos + icon_h / 2],
-            marker=dict(size=marker_size, color=self.color, opacity=0),
-            customdata=[customdata],
-            hovertemplate=hovertemplate,
-            hoverinfo="text",
-            name=self.tag,
-            legendgroup="bearings",
-            showlegend=False,
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_body,
+                y=y_body,
+                mode="lines",
+                fill="toself",
+                fillcolor=shades["dark"],
+                line=dict(width=1.0, color=shades["edge"]),
+                name=self.tag,
+                legendgroup=self._legend_group,
+                showlegend=False,
+                hoverinfo="skip",
+            )
         )
-        fig.add_trace(go.Scatter(**hover_marker_values_top))
-        # copy the customdata and hovertemplate from the top marker just multiplying the y value by -1
-        hover_marker_values_bottom = hover_marker_values_top.copy()
-        hover_marker_values_bottom["y"] = [-1 * hover_marker_values_top["y"][0]]
-        fig.add_trace(go.Scatter(**hover_marker_values_bottom))
 
-        # plot top base
-        x_top = [zpos, zpos, zs0, zs1]
-        yl_top = [
-            ypos + icon_h,
-            ypos + 0.75 * icon_h,
-            ypos + 0.75 * icon_h,
-            ypos + 0.75 * icon_h,
-        ]
-        yu_top = [-y for y in yl_top]
-        fig.add_trace(go.Scatter(x=x_top, y=np.add(yl_top, yc_pos), **default_values))
-        fig.add_trace(go.Scatter(x=x_top, y=np.add(yu_top, yc_pos), **default_values))
-
-        # plot ground
         if self.n_link is None:
-            zl_g = [zs0 - step, zs1 + step]
-            yl_g = [yl_top[0], yl_top[0]]
-            yu_g = [-y for y in yl_g]
-            fig.add_trace(go.Scatter(x=zl_g, y=np.add(yl_g, yc_pos), **default_values))
-            fig.add_trace(go.Scatter(x=zl_g, y=np.add(yu_g, yc_pos), **default_values))
-
-            step2 = (zl_g[1] - zl_g[0]) / n
-            for i in range(n + 1):
-                zl_g2 = [(zs0 - step) + step2 * (i), (zs0 - step) + step2 * (i + 1)]
-                yl_g2 = [yl_g[0], 1.1 * yl_g[0]]
-                yu_g2 = [-y for y in yl_g2]
-                fig.add_trace(
-                    go.Scatter(x=zl_g2, y=np.add(yl_g2, yc_pos), **default_values)
+            fig.add_trace(
+                go.Scatter(
+                    x=x_ground,
+                    y=y_ground,
+                    mode="lines",
+                    line=dict(width=3.5, color=shades["edge"]),
+                    name=self.tag,
+                    legendgroup=self._legend_group,
+                    showlegend=False,
+                    hoverinfo="skip",
                 )
-                fig.add_trace(
-                    go.Scatter(x=zl_g2, y=np.add(yu_g2, yc_pos), **default_values)
-                )
+            )
 
-        # plot spring
-        z_spring = np.array([zs0, zs0, zs0, zs0])
-        yl_spring = np.array([ys0, ys0 + step, ys0 + icon_w - step, ys0 + icon_w])
-
-        for i in range(coils):
-            z_spring = np.insert(z_spring, i + 2, zs0 - (-1) ** i * step)
-            yl_spring = np.insert(yl_spring, i + 2, ys0 + (i + 1) * step)
-        yu_spring = [-y for y in yl_spring]
-
+        marker_size = min(max(icon_h * 200, 14.0), 34.0)
         fig.add_trace(
-            go.Scatter(x=z_spring, y=np.add(yl_spring, yc_pos), **default_values)
-        )
-        fig.add_trace(
-            go.Scatter(x=z_spring, y=np.add(yu_spring, yc_pos), **default_values)
-        )
-
-        # plot damper - base
-        z_damper1 = [zs1, zs1]
-        yl_damper1 = [ys0, ys0 + 2 * step]
-        yu_damper1 = [-y for y in yl_damper1]
-        fig.add_trace(
-            go.Scatter(x=z_damper1, y=np.add(yl_damper1, yc_pos), **default_values)
-        )
-        fig.add_trace(
-            go.Scatter(x=z_damper1, y=np.add(yu_damper1, yc_pos), **default_values)
-        )
-
-        # plot damper - center
-        z_damper2 = [zs1 - 2 * step, zs1 - 2 * step, zs1 + 2 * step, zs1 + 2 * step]
-        yl_damper2 = [ys0 + 5 * step, ys0 + 2 * step, ys0 + 2 * step, ys0 + 5 * step]
-        yu_damper2 = [-y for y in yl_damper2]
-        fig.add_trace(
-            go.Scatter(x=z_damper2, y=np.add(yl_damper2, yc_pos), **default_values)
-        )
-        fig.add_trace(
-            go.Scatter(x=z_damper2, y=np.add(yu_damper2, yc_pos), **default_values)
-        )
-
-        # plot damper - top
-        z_damper3 = [z_damper2[0], z_damper2[2], zs1, zs1]
-        yl_damper3 = [
-            ys0 + 4 * step,
-            ys0 + 4 * step,
-            ys0 + 4 * step,
-            ypos + 1.5 * icon_w,
-        ]
-        yu_damper3 = [-y for y in yl_damper3]
-
-        fig.add_trace(
-            go.Scatter(x=z_damper3, y=np.add(yl_damper3, yc_pos), **default_values)
-        )
-        fig.add_trace(
-            go.Scatter(x=z_damper3, y=np.add(yu_damper3, yc_pos), **default_values)
+            go.Scatter(
+                x=[zpos, zpos],
+                y=[
+                    (ypos + ypos_s) / 2 + yc_pos,
+                    -(ypos + ypos_s) / 2 + yc_pos,
+                ],
+                mode="markers",
+                marker=dict(size=marker_size, color=self.color, opacity=0),
+                customdata=[customdata] * 2,
+                text=hovertemplate,
+                hovertemplate=hovertemplate,
+                hoverinfo="text",
+                hoverlabel=dict(bgcolor=shades["dark"], font=dict(color="white")),
+                name=self.tag,
+                legendgroup=self._legend_group,
+                showlegend=False,
+            )
         )
 
         return fig
@@ -1458,6 +1400,8 @@ class SealElement(BearingElement):
            [  0.,   0.,   0.]])
     """
 
+    _legend_group = "Seal"
+
     @check_units
     def __init__(
         self,
@@ -1575,6 +1519,91 @@ class SealElement(BearingElement):
         customdata = [self.n]
 
         return customdata, hovertemplate
+
+    def _patch(self, position, fig):
+        """Seal element patch.
+
+        Patch that will be used to draw the seal element using Plotly library.
+        The seal is drawn as a slim block with labyrinth teeth pointing at the
+        shaft surface.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y_low, y_upp, y_center) in which the patch will be
+            drawn.
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+
+        Returns
+        -------
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+        """
+        zpos, ypos, ypos_s, yc_pos = position
+        shades = color_shades(self.color)
+
+        icon_h = ypos_s - ypos
+        icon_w = 0.15 * icon_h
+        teeth = 4
+
+        x_body = []
+        y_body = []
+        for sign in (1, -1):
+            y0 = sign * ypos + yc_pos
+            y_top = y0 + sign * 0.52 * icon_h
+            y_root = y0 + sign * 0.20 * icon_h
+            y_tip = y0 + sign * 0.04 * icon_h
+
+            x_body += [zpos - icon_w, zpos + icon_w, zpos + icon_w]
+            y_body += [y_top, y_top, y_root]
+            for x_tooth in np.linspace(zpos + icon_w, zpos - icon_w, 2 * teeth + 1)[
+                1::2
+            ]:
+                x_body += [x_tooth + 0.17 * icon_w, x_tooth, x_tooth - 0.17 * icon_w]
+                y_body += [y_root, y_tip, y_root]
+            x_body += [zpos - icon_w, zpos - icon_w, None]
+            y_body += [y_root, y_top, None]
+
+        customdata, hovertemplate = self._hover_info()
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_body,
+                y=y_body,
+                mode="lines",
+                fill="toself",
+                fillcolor=shades["base"],
+                line=dict(width=1.0, color=shades["edge"]),
+                name=self.tag,
+                legendgroup=self._legend_group,
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+        marker_size = min(max(icon_h * 200, 14.0), 34.0)
+        fig.add_trace(
+            go.Scatter(
+                x=[zpos, zpos],
+                y=[
+                    (ypos + ypos_s) / 2 + yc_pos,
+                    -(ypos + ypos_s) / 2 + yc_pos,
+                ],
+                mode="markers",
+                marker=dict(size=marker_size, color=self.color, opacity=0),
+                customdata=[customdata] * 2,
+                text=hovertemplate,
+                hovertemplate=hovertemplate,
+                hoverinfo="text",
+                hoverlabel=dict(bgcolor=shades["base"], font=dict(color="white")),
+                name=self.tag,
+                legendgroup=self._legend_group,
+                showlegend=False,
+            )
+        )
+
+        return fig
 
 
 class BallBearingElement(BearingElement):

--- a/ross/coupling_element.py
+++ b/ross/coupling_element.py
@@ -110,6 +110,8 @@ class CouplingElement(ShaftElement):
     0.54925
     """
 
+    _legend_group = "Coupling"
+
     @check_units
     def __init__(
         self,
@@ -522,7 +524,7 @@ class CouplingElement(ShaftElement):
             else self.tag
         )
 
-        legend = "Coupling"
+        legend = self._legend_group
 
         customdata = [
             self.n,

--- a/ross/disk_element.py
+++ b/ross/disk_element.py
@@ -8,6 +8,7 @@ import numpy as np
 from plotly import graph_objects as go
 
 from ross.element import Element
+from ross.plotly_theme import color_shades
 from ross.units import check_units
 from ross.utils import read_table_file
 
@@ -49,6 +50,8 @@ class DiskElement(Element):
     >>> disk.Ip
     0.3
     """
+
+    _legend_group = "Disk"
 
     @check_units
     def __init__(self, n, m, Id, Ip, tag=None, scale_factor=1.0, color="Firebrick"):
@@ -355,10 +358,15 @@ class DiskElement(Element):
 
         Patch that will be used to draw the shaft element using plotly library.
 
+        The disk is drawn as an I shaped cross section (hub, web and rim), with
+        its height scaled by the disk mass relative to the heaviest disk in the
+        rotor.
+
         Parameters
         ----------
-        position : float
-            Position in which the patch will be drawn.
+        position : tuple
+            Position (z, y_low, y_center, height) in which the patch will be
+            drawn.
         fig : plotly.graph_objects.Figure
             The figure object which traces are added on.
 
@@ -367,23 +375,15 @@ class DiskElement(Element):
         fig : plotly.graph_objects.Figure
             The figure object which traces are added on.
         """
-        zpos, ypos, yc_pos, scale_factor = position
-        radius = scale_factor / 8
+        zpos, ypos, yc_pos, height = position
+        shades = color_shades(self.color)
 
-        # coordinates to plot disks elements
-        z_upper = [zpos, zpos + scale_factor / 25, zpos - scale_factor / 25, zpos]
-        y_upper = [ypos, ypos + 2 * scale_factor, ypos + 2 * scale_factor, ypos]
-
-        z_lower = [zpos, zpos + scale_factor / 25, zpos - scale_factor / 25, zpos]
-        y_lower = [-ypos, -ypos - 2 * scale_factor, -ypos - 2 * scale_factor, -ypos]
-
-        z_pos = z_upper
-        z_pos.append(None)
-        z_pos.extend(z_lower)
-
-        y_pos = y_upper
-        y_upper.append(None)
-        y_pos.extend(y_lower)
+        # axial width of a uniform disk with the same mass and inertias
+        width = 12 * (self.Id - self.Ip / 2) / self.m if self.m else 0
+        width = np.sqrt(width) if width > 0 else 0
+        width = min(max(width, 0.28 * height), 1.5 * height)
+        rim = width / 2
+        hub = 0.45 * rim
 
         customdata = [self.n, self.Ip, self.Id, self.m]
         hovertemplate = (
@@ -393,53 +393,81 @@ class DiskElement(Element):
             + f"Disk mass: {customdata[3]:.3f}<br>"
         )
 
-        fig.add_trace(
-            go.Scatter(
+        # fmt: off
+        z_offsets = [-rim, rim, rim, hub, hub, rim, rim, -rim, -rim, -hub, -hub, -rim, -rim]
+        y_factors = [0, 0, 0.14, 0.20, 0.78, 0.84, 1, 1, 0.84, 0.78, 0.20, 0.14, 0]
+        # fmt: on
+
+        sheen_color = "rgba(255,255,255,0.30)"
+
+        for sign in (1, -1):
+            y0 = sign * ypos + yc_pos
+            h = sign * height
+            z_pos = [zpos + dz for dz in z_offsets]
+            y_pos = [y0 + factor * h for factor in y_factors]
+
+            body = go.Scatter(
                 x=z_pos,
-                y=[y + yc_pos if y is not None else None for y in y_pos],
+                y=y_pos,
                 customdata=[customdata] * len(z_pos),
                 text=hovertemplate,
                 mode="lines",
                 fill="toself",
-                fillcolor=self.color,
-                opacity=0.8,
-                line=dict(width=2.0, color=self.color),
+                fillcolor=shades["dark"],
+                fillpattern=dict(
+                    shape="",
+                    fgcolor=shades["edge"],
+                    bgcolor=shades["section"],
+                    size=4,
+                    solidity=0.25,
+                ),
+                line=dict(width=1.0, color=shades["edge"]),
                 showlegend=False,
                 name=self.tag,
-                legendgroup="disks",
+                legendgroup=self._legend_group,
                 hoveron="points+fills",
                 hoverinfo="text",
                 hovertemplate=hovertemplate,
-                hoverlabel=dict(bgcolor=self.color),
+                hoverlabel=dict(bgcolor=shades["dark"], font=dict(color="white")),
             )
-        )
+            sheen = go.Scatter(
+                x=[zpos - 0.2 * rim] * 2,
+                y=[y0 + 0.06 * h, y0 + 0.92 * h],
+                mode="lines",
+                line=dict(width=2.0, color=sheen_color),
+                showlegend=False,
+                legendgroup=self._legend_group,
+                hoverinfo="skip",
+            )
 
-        fig.add_shape(
-            dict(
-                type="circle",
-                xref="x",
-                yref="y",
-                x0=zpos - radius,
-                y0=y_upper[1] - radius + yc_pos,
-                x1=zpos + radius,
-                y1=y_upper[1] + radius + yc_pos,
-                fillcolor=self.color,
-                line_color=self.color,
-            )
-        )
-        fig.add_shape(
-            dict(
-                type="circle",
-                xref="x",
-                yref="y",
-                x0=zpos - radius,
-                y0=y_lower[1] - radius + yc_pos,
-                x1=zpos + radius,
-                y1=y_lower[1] + radius + yc_pos,
-                fillcolor=self.color,
-                line_color=self.color,
-            )
-        )
+            if sign < 0:
+                body.update(
+                    meta=dict(
+                        morph=dict(
+                            render={
+                                "fillcolor": shades["dark"],
+                                "fillpattern.shape": "",
+                                "line.color": shades["edge"],
+                            },
+                            section={
+                                "fillcolor": shades["section"],
+                                "fillpattern.shape": "/",
+                                "line.color": shades["edge"],
+                            },
+                        )
+                    )
+                )
+                sheen.update(
+                    meta=dict(
+                        morph=dict(
+                            render={"line.color": sheen_color},
+                            section={"line.color": "rgba(255,255,255,0)"},
+                        )
+                    )
+                )
+
+            fig.add_trace(body)
+            fig.add_trace(sheen)
 
         return fig
 

--- a/ross/gear_element.py
+++ b/ross/gear_element.py
@@ -13,6 +13,7 @@ from warnings import warn
 from ross.units import Q_, check_units
 from ross.materials import steel
 from ross.disk_element import DiskElement
+from ross.plotly_theme import color_shades
 from ross.materials import steel
 
 
@@ -99,6 +100,8 @@ class GearElement(DiskElement):
     >>> gear.base_radius # doctest: +ELLIPSIS
     0.086382...
     """
+
+    _legend_group = "Gear"
 
     @check_units
     def __init__(
@@ -274,6 +277,7 @@ class GearElement(DiskElement):
         """
         zpos, ypos, yc_pos, scale_factor = position
         scale_factor *= 2
+        shades = color_shades(self.color)
         radius = min(self.base_radius * 1.1 + 0.05, 1)
 
         z_upper = [
@@ -317,19 +321,22 @@ class GearElement(DiskElement):
                 text=hovertemplate,
                 mode="lines",
                 fill="toself",
-                fillcolor=self.color,
+                fillcolor=shades["dark"],
                 fillpattern=dict(
-                    shape="/", fgcolor="rgba(0, 0, 0, 0.2)", bgcolor=self.color
+                    shape="/",
+                    fgcolor=shades["edge"],
+                    bgcolor=shades["dark"],
+                    size=4,
+                    solidity=0.25,
                 ),
-                opacity=0.8,
-                line=dict(width=2.0, color="rgba(0, 0, 0, 0.2)"),
+                line=dict(width=1.0, color=shades["edge"]),
                 showlegend=False,
                 name=self.tag,
-                legendgroup="gears",
+                legendgroup=self._legend_group,
                 hoveron="points+fills",
                 hoverinfo="text",
                 hovertemplate=hovertemplate,
-                hoverlabel=dict(bgcolor=self.color),
+                hoverlabel=dict(bgcolor=shades["dark"], font=dict(color="white")),
             )
         )
 

--- a/ross/multi_rotor.py
+++ b/ross/multi_rotor.py
@@ -168,7 +168,7 @@ class MultiRotor(Rotor):
             (
                 elm
                 for elm in R1.plot_rotor().data
-                if elm["legendgroup"] == "gears"
+                if elm["legendgroup"] == GearElement._legend_group
                 and int(search(r"Gear Node: (\d+)", elm.text).group(1)) == gear_1.n
             ),
             None,
@@ -178,7 +178,7 @@ class MultiRotor(Rotor):
             (
                 elm
                 for elm in R2.plot_rotor().data
-                if elm["legendgroup"] == "gears"
+                if elm["legendgroup"] == GearElement._legend_group
                 and int(search(r"Gear Node: (\d+)", elm.text).group(1)) == gear_2.n
             ),
             None,

--- a/ross/plotly_theme.py
+++ b/ross/plotly_theme.py
@@ -1,5 +1,7 @@
 """Plotly theme to ROSS - Rotordynamic Open Source Sofware."""
 
+import re
+
 from plotly import graph_objects as go
 from plotly import io as pio
 
@@ -16,6 +18,174 @@ tableau_colors = {
     "olive": "#bcbd22",
     "cyan": "#17becf",
 }
+
+# CSS extended color keywords. Plotly validates named colors but does not expose
+# a name to hex map on the Python side, so the table is needed to derive shades
+# from element colors given as names (e.g. the "Firebrick" disk default).
+# fmt: off
+css_named_colors = {
+    "aliceblue": "#f0f8ff", "antiquewhite": "#faebd7", "aqua": "#00ffff",
+    "aquamarine": "#7fffd4", "azure": "#f0ffff", "beige": "#f5f5dc",
+    "bisque": "#ffe4c4", "black": "#000000", "blanchedalmond": "#ffebcd",
+    "blue": "#0000ff", "blueviolet": "#8a2be2", "brown": "#a52a2a",
+    "burlywood": "#deb887", "cadetblue": "#5f9ea0", "chartreuse": "#7fff00",
+    "chocolate": "#d2691e", "coral": "#ff7f50", "cornflowerblue": "#6495ed",
+    "cornsilk": "#fff8dc", "crimson": "#dc143c", "cyan": "#00ffff",
+    "darkblue": "#00008b", "darkcyan": "#008b8b", "darkgoldenrod": "#b8860b",
+    "darkgray": "#a9a9a9", "darkgrey": "#a9a9a9", "darkgreen": "#006400",
+    "darkkhaki": "#bdb76b", "darkmagenta": "#8b008b",
+    "darkolivegreen": "#556b2f", "darkorange": "#ff8c00",
+    "darkorchid": "#9932cc", "darkred": "#8b0000", "darksalmon": "#e9967a",
+    "darkseagreen": "#8fbc8f", "darkslateblue": "#483d8b",
+    "darkslategray": "#2f4f4f", "darkslategrey": "#2f4f4f",
+    "darkturquoise": "#00ced1", "darkviolet": "#9400d3", "deeppink": "#ff1493",
+    "deepskyblue": "#00bfff", "dimgray": "#696969", "dimgrey": "#696969",
+    "dodgerblue": "#1e90ff", "firebrick": "#b22222", "floralwhite": "#fffaf0",
+    "forestgreen": "#228b22", "fuchsia": "#ff00ff", "gainsboro": "#dcdcdc",
+    "ghostwhite": "#f8f8ff", "gold": "#ffd700", "goldenrod": "#daa520",
+    "gray": "#808080", "grey": "#808080", "green": "#008000",
+    "greenyellow": "#adff2f", "honeydew": "#f0fff0", "hotpink": "#ff69b4",
+    "indianred": "#cd5c5c", "indigo": "#4b0082", "ivory": "#fffff0",
+    "khaki": "#f0e68c", "lavender": "#e6e6fa", "lavenderblush": "#fff0f5",
+    "lawngreen": "#7cfc00", "lemonchiffon": "#fffacd", "lightblue": "#add8e6",
+    "lightcoral": "#f08080", "lightcyan": "#e0ffff",
+    "lightgoldenrodyellow": "#fafad2", "lightgray": "#d3d3d3",
+    "lightgrey": "#d3d3d3", "lightgreen": "#90ee90", "lightpink": "#ffb6c1",
+    "lightsalmon": "#ffa07a", "lightseagreen": "#20b2aa",
+    "lightskyblue": "#87cefa", "lightslategray": "#778899",
+    "lightslategrey": "#778899", "lightsteelblue": "#b0c4de",
+    "lightyellow": "#ffffe0", "lime": "#00ff00", "limegreen": "#32cd32",
+    "linen": "#faf0e6", "magenta": "#ff00ff", "maroon": "#800000",
+    "mediumaquamarine": "#66cdaa", "mediumblue": "#0000cd",
+    "mediumorchid": "#ba55d3", "mediumpurple": "#9370db",
+    "mediumseagreen": "#3cb371", "mediumslateblue": "#7b68ee",
+    "mediumspringgreen": "#00fa9a", "mediumturquoise": "#48d1cc",
+    "mediumvioletred": "#c71585", "midnightblue": "#191970",
+    "mintcream": "#f5fffa", "mistyrose": "#ffe4e1", "moccasin": "#ffe4b5",
+    "navajowhite": "#ffdead", "navy": "#000080", "oldlace": "#fdf5e6",
+    "olive": "#808000", "olivedrab": "#6b8e23", "orange": "#ffa500",
+    "orangered": "#ff4500", "orchid": "#da70d6", "palegoldenrod": "#eee8aa",
+    "palegreen": "#98fb98", "paleturquoise": "#afeeee",
+    "palevioletred": "#db7093", "papayawhip": "#ffefd5", "peachpuff": "#ffdab9",
+    "peru": "#cd853f", "pink": "#ffc0cb", "plum": "#dda0dd",
+    "powderblue": "#b0e0e6", "purple": "#800080", "rebeccapurple": "#663399",
+    "red": "#ff0000", "rosybrown": "#bc8f8f", "royalblue": "#4169e1",
+    "saddlebrown": "#8b4513", "salmon": "#fa8072", "sandybrown": "#f4a460",
+    "seagreen": "#2e8b57", "seashell": "#fff5ee", "sienna": "#a0522d",
+    "silver": "#c0c0c0", "skyblue": "#87ceeb", "slateblue": "#6a5acd",
+    "slategray": "#708090", "slategrey": "#708090", "snow": "#fffafa",
+    "springgreen": "#00ff7f", "steelblue": "#4682b4", "tan": "#d2b48c",
+    "teal": "#008080", "thistle": "#d8bfd8", "tomato": "#ff6347",
+    "turquoise": "#40e0d0", "violet": "#ee82ee", "wheat": "#f5deb3",
+    "white": "#ffffff", "whitesmoke": "#f5f5f5", "yellow": "#ffff00",
+    "yellowgreen": "#9acd32",
+}
+# fmt: on
+
+DEFAULT_COLOR = "#525252"
+
+
+def parse_color(color):
+    """Convert a color specification to an (r, g, b) tuple.
+
+    Hexadecimal (short or long), ``rgb()``/``rgba()`` functional notation and
+    CSS color names are understood. Anything that cannot be interpreted falls
+    back to the ROSS default element color.
+
+    Parameters
+    ----------
+    color : str
+        Color specification (e.g. "#b22222", "#b22", "rgb(178, 34, 34)",
+        "Firebrick").
+
+    Returns
+    -------
+    rgb : tuple
+        Tuple with the red, green and blue channels as integers in 0-255.
+
+    Examples
+    --------
+    >>> parse_color("#b22222")
+    (178, 34, 34)
+    >>> parse_color("Firebrick")
+    (178, 34, 34)
+    >>> parse_color("rgba(178, 34, 34, 0.5)")
+    (178, 34, 34)
+    >>> parse_color("not a color")
+    (82, 82, 82)
+    """
+    spec = str(color).strip().lower()
+    spec = css_named_colors.get(spec, spec)
+
+    if spec.startswith("#"):
+        digits = spec[1:]
+        if len(digits) == 3:
+            digits = "".join(2 * digit for digit in digits)
+        if len(digits) == 6:
+            try:
+                return tuple(int(digits[i : i + 2], 16) for i in (0, 2, 4))
+            except ValueError:
+                pass
+
+    if spec.startswith("rgb"):
+        channels = re.findall(r"[\d.]+", spec)
+        if len(channels) >= 3:
+            return tuple(int(round(float(value))) for value in channels[:3])
+
+    return (82, 82, 82)
+
+
+def color_shades(color):
+    """Derive the set of shades used to draw an element from a single color.
+
+    Every shade in the rotor plot comes from the element color, so that setting
+    ``Material.color``, ``DiskElement.color`` or ``BearingElement.color``
+    controls the whole appearance of that element.
+
+    Parameters
+    ----------
+    color : str
+        Color specification, as accepted by :py:func:`parse_color`.
+
+    Returns
+    -------
+    shades : dict
+        Dictionary with the keys:
+
+        base
+            The color itself, used for legend swatches.
+        tint
+            Translucent wash applied over the rendered metal.
+        section
+            Lighter fill used for the material cross section.
+        edge
+            Darker shade used for outlines and hatch strokes.
+        dark
+            Slightly darker shade used for solid glyph fills.
+
+    Examples
+    --------
+    >>> color_shades("Firebrick")["section"]
+    '#d58585'
+    >>> color_shades("Firebrick")["tint"]
+    'rgba(178,34,34,0.30)'
+    """
+    rgb = parse_color(color)
+
+    def mix(target, factor):
+        return "#%02x%02x%02x" % tuple(
+            round(channel * (1 - factor) + target * factor) for channel in rgb
+        )
+
+    return dict(
+        base=mix(0, 0),
+        tint="rgba({},{},{},0.30)".format(*rgb),
+        section=mix(255, 0.45),
+        edge=mix(0, 0.35),
+        dark=mix(0, 0.15),
+    )
+
+
 pio.templates["ross"] = go.layout.Template(
     layout={
         "annotationdefaults": {

--- a/ross/point_mass.py
+++ b/ross/point_mass.py
@@ -7,6 +7,7 @@ import numpy as np
 from plotly import graph_objects as go
 
 from ross.element import Element
+from ross.plotly_theme import color_shades
 from ross.units import check_units
 
 __all__ = ["PointMass"]
@@ -54,6 +55,8 @@ class PointMass(Element):
            [0., 3., 0.],
            [0., 0., 4.]])
     """
+
+    _legend_group = "Point mass"
 
     @check_units
     def __init__(
@@ -294,8 +297,7 @@ class PointMass(Element):
             The figure object which traces are added on.
         """
         zpos, ypos, yc_pos = position
-
-        radius = 0.005 * self.scale_factor
+        shades = color_shades(self.color)
 
         customdata = [self.n, self.mx, self.my, self.mz]
         hovertemplate = (
@@ -312,40 +314,18 @@ class PointMass(Element):
                 customdata=[customdata] * 2,
                 text=hovertemplate,
                 mode="markers",
-                marker=dict(size=5.0, color=self.color),
+                marker=dict(
+                    size=11.0,
+                    symbol="diamond",
+                    color=shades["dark"],
+                    line=dict(width=1.0, color=shades["edge"]),
+                ),
                 showlegend=False,
                 name=self.tag,
-                legendgroup="pointmass",
+                legendgroup=self._legend_group,
                 hoverinfo="text",
                 hovertemplate=hovertemplate,
-                hoverlabel=dict(bgcolor=self.color),
-            )
-        )
-
-        fig.add_shape(
-            dict(
-                type="circle",
-                xref="x",
-                yref="y",
-                x0=zpos - radius,
-                y0=ypos - radius + yc_pos,
-                x1=zpos + radius,
-                y1=ypos + radius + yc_pos,
-                fillcolor=self.color,
-                line_color="black",
-            )
-        )
-        fig.add_shape(
-            dict(
-                type="circle",
-                xref="x",
-                yref="y",
-                x0=zpos - radius,
-                y0=-ypos - radius + yc_pos,
-                x1=zpos + radius,
-                y1=-ypos + radius + yc_pos,
-                fillcolor=self.color,
-                line_color="black",
+                hoverlabel=dict(bgcolor=shades["dark"], font=dict(color="white")),
             )
         )
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -41,6 +41,7 @@ from ross.disk_element import DiskElement
 from ross.faults import Crack, MisalignmentFlex, MisalignmentRigid, Rubbing
 from ross.materials import Material, steel
 from ross.model_reduction import ModelReduction
+from ross.plotly_theme import color_shades
 from ross.point_mass import PointMass
 from ross.probe import Probe
 from ross.results import (
@@ -84,6 +85,113 @@ __all__ = [
 
 # set Plotly palette of colors
 colors = px.colors.qualitative.Dark24
+
+RENDER_COLORSCALE = [
+    [0.0, "#252F3A"],
+    [0.28, "#49596A"],
+    [0.55, "#7E93A6"],
+    [0.80, "#C2CFDB"],
+    [1.0, "#F4F8FB"],
+]
+
+
+def _shaft_envelope(spans, columns=300):
+    """Build the axial grid and the outer radius envelope of a set of elements.
+
+    Heatmap cells are centered on their coordinates, so a uniform grid would
+    bleed half a cell past each diameter step. The grid is built with two
+    columns tight against each element boundary, which places the cell edges
+    exactly on the boundary. Where elements overlap, as in a sleeve mounted on
+    the shaft, the envelope is the largest radius.
+
+    Columns are only added inside a span where the shaft is conical, since the
+    shading of a cylindrical span is the same along its whole length.
+
+    Parameters
+    ----------
+    spans : list
+        List of (axial position, length, left outer diameter, right outer
+        diameter) tuples, one for each element.
+    columns : int, optional
+        Approximate number of columns used to resolve conical spans.
+        Default is 300.
+
+    Returns
+    -------
+    z_grid : np.ndarray
+        Axial positions of the grid columns.
+    radius : np.ndarray
+        Outer radius of the shaft at each column, NaN where there is no
+        material.
+
+    Examples
+    --------
+    >>> z_grid, radius = _shaft_envelope([(0.0, 0.5, 0.1, 0.1)])
+    >>> float(z_grid[0]), float(radius[0])
+    (1e-07, 0.05)
+    """
+    eps = 1e-7
+    bounds = sorted(
+        {round(z0, 9) for z0, _, _, _ in spans}
+        | {round(z0 + length, 9) for z0, length, _, _ in spans}
+    )
+    target = (bounds[-1] - bounds[0]) / columns
+
+    centers = []
+    for start, end in zip(bounds[:-1], bounds[1:]):
+        segment = end - start
+        if segment < 8 * eps:
+            continue
+        conical = any(
+            odl != odr and z0 - 1e-9 <= start and end <= z0 + length + 1e-9
+            for z0, length, odl, odr in spans
+        )
+        inner = max(0, int(np.ceil(segment / target)) - 1) if conical else 0
+        centers += [start + eps, start + 3 * eps]
+        centers += list(start + np.arange(1, inner + 1) / (inner + 1) * segment)
+        centers += [end - 3 * eps, end - eps]
+
+    z_grid = np.array(centers)
+    radius = np.zeros(len(z_grid))
+    for z0, length, odl, odr in spans:
+        inside = (z_grid >= z0 - 1e-9) & (z_grid <= z0 + length + 1e-9)
+        ratio = np.clip((z_grid - z0) / length, 0, 1)
+        element_radius = np.where(
+            inside, (odl / 2) * (1 - ratio) + (odr / 2) * ratio, -1.0
+        )
+        larger = element_radius > radius + 1e-12
+        radius[larger] = element_radius[larger]
+
+    radius[radius == 0] = np.nan
+
+    return z_grid, radius
+
+
+def _cylinder_shading(relative_radius):
+    """Shade the shaft as a cylinder lit from above the center line.
+
+    Parameters
+    ----------
+    relative_radius : np.ndarray
+        Radial position of each point divided by the outer radius of the shaft.
+
+    Returns
+    -------
+    shading : np.ndarray
+        Light intensity in the 0 to 1 range, NaN outside the shaft.
+
+    Examples
+    --------
+    >>> _cylinder_shading(np.array([0.0, 0.5, 1.5])).round(3)
+    array([0.862, 0.928,   nan])
+    """
+    u = np.abs(relative_radius)
+    intensity = np.sqrt(np.clip(1 - u**2, 0, 1))
+    specular = np.exp(-(((u - 0.40) / 0.18) ** 2)) * intensity
+    shading = np.clip(0.16 + 0.70 * intensity**0.75 + 0.22 * specular, 0, 1)
+    shading[u > 1] = np.nan
+
+    return shading
 
 
 class Rotor(object):
@@ -3044,10 +3152,21 @@ class Rotor(object):
         This function will take a rotor object and plot its elements representation
         using Plotly.
 
+        The shaft is drawn as rendered metal above the center line, and two
+        buttons switch the half below it between the same rendered look and a
+        material cross section, where each material is hatched in its own color
+        and the bore of hollow elements is left void. Every shade in the plot is
+        derived from a single color per element, so setting `Material.color`,
+        `DiskElement.color` or `BearingElement.color` controls the whole
+        appearance of that element. Below the rotor there is a scale with the
+        node numbers; hovering a node drops a guide line across the rotor.
+
         Parameters
         ----------
         nodes : int, optional
-            Increment that will be used to plot nodes label.
+            Increment that will be used to plot nodes label. Labels which would
+            be printed over each other are dropped, but every node can still be
+            hovered on the node scale.
         check_sld : bool
             If True, checks the slenderness ratio for each element.
             The shaft elements which has a slenderness ratio < 1.6 will be displayed in
@@ -3089,51 +3208,12 @@ class Rotor(object):
         nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
         nodes_o_d = Q_(self.nodes_o_d, "m").to(length_units).m
         center_line_pos = Q_(self.center_line_pos, "m").to(length_units).m
+        mean_od = np.mean(nodes_o_d)
 
         fig = go.Figure()
 
-        # plot shaft centerline
-        fig.add_shape(
-            x0=0,
-            x1=1,
-            y0=0,
-            y1=0,
-            xref="paper",
-            yref="y",
-            layer="below",
-            opacity=0.7,
-            type="line",
-            line=dict(width=3.0, color="black", dash="dashdot"),
-        )
+        self._plot_shaft_render(fig, length_units)
 
-        # plot nodes icons
-        text = []
-        x_pos = []
-        y_pos = np.linspace(0, 0, len(nodes_pos[::nodes]))
-        for i, position in enumerate(nodes_pos[::nodes]):
-            node = self.nodes[i]
-            text.append("{}".format(node * nodes))
-            x_pos.append(position)
-            y_pos[i] = center_line_pos[i]
-
-        fig.add_trace(
-            go.Scatter(
-                x=x_pos,
-                y=y_pos,
-                text=text,
-                mode="markers+text",
-                marker=dict(
-                    opacity=0.7,
-                    size=20,
-                    color="#ffcc99",
-                    line=dict(width=1.0, color="black"),
-                ),
-                showlegend=False,
-                hoverinfo="none",
-            )
-        )
-
-        # plot shaft elements
         for sh_elm in self.shaft_elements:
             i = self.nodes.index(sh_elm.n)
             z_pos = self.nodes_pos[i]
@@ -3142,9 +3222,8 @@ class Rotor(object):
             position = (z_pos, yc_pos)
             fig = sh_elm._patch(position, check_sld, fig, length_units)
 
-        mean_od = np.mean(nodes_o_d)
+        self._plot_center_line(fig, length_units)
 
-        # plot disk elements
         # calculate scale factor if disks have scale_factor='mass'
         if self.disk_elements:
             scaled_disks = [
@@ -3156,11 +3235,14 @@ class Rotor(object):
                     f = disk.m / max_mass
                     disk._scale_factor_calculated = (1 - f) * 0.5 + f * 1.0
 
+            heaviest = max([disk.m for disk in self.disk_elements])
+
             for disk in self.disk_elements:
                 scale_factor = disk.scale_factor
                 if scale_factor == "mass":
                     scale_factor = disk._scale_factor_calculated
-                step = scale_factor * mean_od
+                mass_ratio = disk.m / heaviest if heaviest else 1.0
+                height = mean_od * (0.70 + 0.55 * mass_ratio) * scale_factor
 
                 z_pos = (
                     Q_(self.df[self.df.tag == disk.tag]["nodes_pos_l"].values[0], "m")
@@ -3173,10 +3255,9 @@ class Rotor(object):
                     .m
                 )
                 yc_pos = center_line_pos[self.nodes.index(disk.n)]
-                position = (z_pos, y_pos, yc_pos, step)
+                position = (z_pos, y_pos, yc_pos, height)
                 fig = disk._patch(position, fig)
 
-        # plot bearings
         for bearing in self.bearing_elements:
             z_pos = (
                 Q_(self.df[self.df.tag == bearing.tag]["nodes_pos_l"].values[0], "m")
@@ -3201,7 +3282,6 @@ class Rotor(object):
             position = (z_pos, y_pos, y_pos_sup, yc_pos)
             bearing._patch(position, fig)
 
-        # plot point mass
         for p_mass in self.point_mass_elements:
             z_pos = (
                 Q_(self.df[self.df.tag == p_mass.tag]["nodes_pos_l"].values[0], "m")
@@ -3221,22 +3301,417 @@ class Rotor(object):
             position = (z_pos, y_pos, yc_pos)
             fig = p_mass._patch(position, fig)
 
+        self._plot_legend_swatches(fig, check_sld)
+
+        y_low = 0.0
+        y_high = 0.0
+        for trace in fig.data:
+            if trace.y is None:
+                continue
+            values = np.array(trace.y, dtype=float)
+            values = values[~np.isnan(values)]
+            if len(values):
+                y_low = min(y_low, values.min())
+                y_high = max(y_high, values.max())
+        y_span = y_high - y_low
+
+        x_pad = 0.04 * np.ptp(nodes_pos)
+        x_range = [min(nodes_pos) - x_pad, max(nodes_pos) + x_pad]
+        y_range = [y_low - 0.16 * y_span, y_high + 0.08 * y_span]
+
+        self._plot_node_scale(
+            fig, nodes, length_units, y_low - 0.11 * y_span, x_range[0]
+        )
+
+        width = 1150
+        margin = dict(l=70, r=25, t=95, b=52)
+        pixels_per_unit = (width - margin["l"] - margin["r"]) / (
+            x_range[1] - x_range[0]
+        )
+        height = (y_range[1] - y_range[0]) * pixels_per_unit
+        height = int(min(max(height + margin["t"] + margin["b"], 300), 900))
+
+        axes = dict(
+            zeroline=False,
+            showline=True,
+            linecolor="#33475C",
+            linewidth=1,
+            mirror=False,
+            ticks="outside",
+            ticklen=4,
+            tickcolor="#33475C",
+        )
         fig.update_xaxes(
             title_text=f"Axial location ({length_units})",
-            showgrid=False,
-            mirror=True,
-            scaleanchor="y",
-            scaleratio=1.5,
+            range=x_range,
+            showgrid=True,
+            gridcolor="#EDF1F5",
+            showspikes=True,
+            spikemode="across",
+            spikesnap="hovered data",
+            spikedash="dot",
+            spikethickness=1.3,
+            spikecolor="#D9480F",
+            **axes,
         )
         fig.update_yaxes(
             title_text=f"Shaft radius ({length_units})",
+            range=y_range,
             showgrid=False,
-            mirror=True,
+            **axes,
         )
+        fig.update_layout(
+            width=width,
+            height=height,
+            margin=margin,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                x=0,
+                itemsizing="constant",
+            ),
+            updatemenus=self._plot_mode_buttons(fig),
+        )
+
         kwargs["title"] = kwargs.get("title", "Rotor Model")
         fig.update_layout(**kwargs)
 
         return fig
+
+    def _plot_shaft_render(self, fig, length_units):
+        """Draw the rendered metal look of the shaft.
+
+        The shaft outer envelope is shaded as a cylinder with a heatmap, one for
+        the upper half and one for the lower half of each center line level. The
+        bore of hollow elements is covered by a mask which becomes white when the
+        lower half is switched to the cross section view.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+        length_units : str
+            Length units used in the plot.
+        """
+        levels = {}
+        for elm in self.shaft_elements:
+            i = self.nodes.index(elm.n)
+            levels.setdefault(self.center_line_pos[i], []).append(
+                (self.nodes_pos[i], elm.L, elm.odl, elm.odr)
+            )
+
+        for yc_pos, spans in levels.items():
+            z_grid, radius = _shaft_envelope(spans)
+            z_grid = Q_(z_grid, "m").to(length_units).m
+            radius = Q_(radius, "m").to(length_units).m
+            yc_pos = Q_(yc_pos, "m").to(length_units).m
+            r_max = np.nanmax(radius)
+
+            for sign in (1, -1):
+                y_grid = sign * np.linspace(0, r_max, 90)
+                with np.errstate(invalid="ignore", divide="ignore"):
+                    shading = _cylinder_shading(y_grid[:, None] / radius[None, :])
+                fig.add_trace(
+                    go.Heatmap(
+                        x=z_grid,
+                        y=y_grid + yc_pos,
+                        z=np.round(shading, 3),
+                        colorscale=RENDER_COLORSCALE,
+                        zmin=0,
+                        zmax=1,
+                        showscale=False,
+                        hoverinfo="skip",
+                    )
+                )
+
+            fig.add_trace(
+                go.Scatter(
+                    x=np.concatenate([z_grid, [None], z_grid]),
+                    y=np.concatenate([radius + yc_pos, [None], -radius + yc_pos]),
+                    mode="lines",
+                    line=dict(width=1.0, color="#31414F"),
+                    showlegend=False,
+                    hoverinfo="skip",
+                )
+            )
+
+        x_void = []
+        y_void = []
+        for elm in self.shaft_elements:
+            if not getattr(elm, "idl", 0) and not getattr(elm, "idr", 0):
+                continue
+            i = self.nodes.index(elm.n)
+            z0 = Q_(self.nodes_pos[i], "m").to(length_units).m
+            z1 = Q_(self.nodes_pos[i] + elm.L, "m").to(length_units).m
+            yc_pos = Q_(self.center_line_pos[i], "m").to(length_units).m
+            idl = Q_(elm.idl, "m").to(length_units).m
+            idr = Q_(elm.idr, "m").to(length_units).m
+            x_void += [z0, z0, z1, z1, z0, None]
+            y_void += [
+                yc_pos,
+                yc_pos - idl / 2,
+                yc_pos - idr / 2,
+                yc_pos,
+                yc_pos,
+                None,
+            ]
+
+        if x_void:
+            fig.add_trace(
+                go.Scatter(
+                    x=x_void,
+                    y=y_void,
+                    mode="lines",
+                    fill="toself",
+                    fillcolor="rgba(0,0,0,0)",
+                    line=dict(width=0.1, color="rgba(0,0,0,0)"),
+                    showlegend=False,
+                    hoverinfo="skip",
+                    meta=dict(
+                        morph=dict(
+                            render={"fillcolor": "rgba(0,0,0,0)"},
+                            section={"fillcolor": "#FFFFFF"},
+                        )
+                    ),
+                )
+            )
+
+    def _plot_center_line(self, fig, length_units):
+        """Draw the center line of each shaft level.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+        length_units : str
+            Length units used in the plot.
+        """
+        nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
+        center_line_pos = Q_(self.center_line_pos, "m").to(length_units).m
+        pad = 0.02 * np.ptp(nodes_pos)
+
+        x_line = []
+        y_line = []
+        for yc_pos in sorted(set(center_line_pos)):
+            nodes_in_level = [
+                pos for pos, level in zip(nodes_pos, center_line_pos) if level == yc_pos
+            ]
+            x_line += [min(nodes_in_level) - pad, max(nodes_in_level) + pad, None]
+            y_line += [yc_pos, yc_pos, None]
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_line,
+                y=y_line,
+                mode="lines",
+                line=dict(color="#8895A3", width=1.1, dash="dashdot"),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+    def _plot_legend_swatches(self, fig, check_sld):
+        """Add one legend entry for each family of elements drawn.
+
+        Element traces carry no legend entry of their own, they only share a
+        legend group with the swatch added here, so that a single legend click
+        hides the whole family.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+        check_sld : bool
+            If True, elements with slenderness ratio < 1.6 have their own entry.
+        """
+        swatches = {}
+
+        for elm in self.shaft_elements:
+            if isinstance(elm, CouplingElement):
+                swatches.setdefault(elm._legend_group, elm.color)
+            elif check_sld and elm.slenderness_ratio < 1.6:
+                swatches["Shaft - Slenderness Ratio < 1.6"] = "yellow"
+            else:
+                swatches[elm.material.name] = elm.material.color
+
+        for element in chain(
+            self.disk_elements, self.bearing_elements, self.point_mass_elements
+        ):
+            swatches.setdefault(element._legend_group, element.color)
+
+        for name, color in swatches.items():
+            shades = color_shades(color)
+            fig.add_trace(
+                go.Scatter(
+                    x=[None],
+                    y=[None],
+                    mode="lines",
+                    fill="toself",
+                    fillcolor=shades["base"],
+                    line=dict(width=1.0, color=shades["edge"]),
+                    name=name,
+                    legendgroup=name,
+                    showlegend=True,
+                    hoverinfo="skip",
+                )
+            )
+
+    def _plot_node_scale(self, fig, nodes, length_units, scale_y, label_x):
+        """Draw the node scale below the rotor.
+
+        Hovering a node of the scale drops a vertical spike line across the
+        rotor, linking the node number to its axial position.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object which traces are added on.
+        nodes : int
+            Increment that will be used to plot nodes label.
+        length_units : str
+            Length units used in the plot.
+        scale_y : float
+            Vertical position of the node scale.
+        label_x : float
+            Horizontal position of the scale title.
+        """
+        nodes_pos = Q_(self.nodes_pos, "m").to(length_units).m
+        center_line_pos = Q_(self.center_line_pos, "m").to(length_units).m
+        tick = 0.012 * abs(scale_y)
+
+        x_ticks = []
+        y_ticks = []
+        for pos, yc_pos in zip(nodes_pos, center_line_pos):
+            x_ticks += [pos, pos, None]
+            y_ticks += [yc_pos - tick, yc_pos + tick, None]
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_ticks,
+                y=y_ticks,
+                mode="lines",
+                line=dict(color="#93A1AF", width=0.8),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+        # labels are dropped where they would be printed over each other
+        min_gap = 0.02 * np.ptp(nodes_pos)
+        x_labels = []
+        text_labels = []
+        for node, pos in sorted(zip(self.nodes, nodes_pos), key=lambda item: item[1]):
+            if node % nodes:
+                continue
+            if x_labels and pos - x_labels[-1] < min_gap:
+                continue
+            x_labels.append(pos)
+            text_labels.append(str(node))
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_labels,
+                y=[scale_y] * len(x_labels),
+                text=text_labels,
+                mode="text",
+                textfont=dict(size=9.5, color="#93A1AF"),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+        fig.add_trace(
+            go.Scatter(
+                x=nodes_pos,
+                y=[scale_y] * len(nodes_pos),
+                mode="markers",
+                marker=dict(size=13, opacity=0),
+                customdata=[[node] for node in self.nodes],
+                hovertemplate=(
+                    "Node %{customdata[0]}<br>"
+                    f"Axial location: %{{x:.4f}} {length_units}<extra></extra>"
+                ),
+                showlegend=False,
+            )
+        )
+
+        fig.add_annotation(
+            x=label_x,
+            y=scale_y,
+            text="node",
+            showarrow=False,
+            xanchor="left",
+            font=dict(size=9.5, color="#93A1AF"),
+        )
+
+    @staticmethod
+    def _plot_mode_buttons(fig):
+        """Build the buttons which switch the look of the lower half.
+
+        Traces which can be drawn in more than one style carry the style values
+        for each mode in their `meta` attribute. The buttons restyle only these
+        style properties, never the trace visibility, which belongs to the
+        legend.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object with the rotor representation.
+
+        Returns
+        -------
+        updatemenus : list
+            List with the plotly updatemenus, empty if no trace can be morphed.
+        """
+        morphs = [
+            (i, trace.meta["morph"])
+            for i, trace in enumerate(fig.data)
+            if isinstance(trace.meta, dict) and "morph" in trace.meta
+        ]
+        if not morphs:
+            return []
+
+        properties = sorted({key for _, morph in morphs for key in morph["render"]})
+
+        def styles(mode):
+            args = {}
+            for prop in properties:
+                values = []
+                for i, morph in morphs:
+                    value = fig.data[i]
+                    for attribute in prop.split("."):
+                        value = value[attribute] if value is not None else None
+                    values.append(morph[mode].get(prop, value))
+                args[prop] = values
+            return [args, [i for i, _ in morphs]]
+
+        return [
+            dict(
+                type="buttons",
+                direction="right",
+                x=1.0,
+                xanchor="right",
+                y=1.02,
+                yanchor="bottom",
+                pad=dict(t=2, b=2),
+                showactive=True,
+                font=dict(size=11),
+                bgcolor="#FFFFFF",
+                bordercolor="#C4CDD6",
+                borderwidth=1,
+                buttons=[
+                    dict(
+                        label="Bottom: render", method="restyle", args=styles("render")
+                    ),
+                    dict(
+                        label="Bottom: section",
+                        method="restyle",
+                        args=styles("section"),
+                    ),
+                ],
+            )
+        ]
 
     @check_units
     def run_campbell(

--- a/ross/shaft_element.py
+++ b/ross/shaft_element.py
@@ -11,6 +11,7 @@ from plotly import graph_objects as go
 
 from ross.element import Element
 from ross.materials import Material
+from ross.plotly_theme import color_shades, parse_color
 from ross.units import Q_, check_units
 from ross.utils import read_table_file
 
@@ -1112,27 +1113,17 @@ class ShaftElement(Element):
             legend = "Shaft - Slenderness Ratio < 1.6"
         else:
             color = self.material.color
-            legend = "Shaft"
+            legend = self.material.name
+
+        shades = color_shades(color)
+        mesh_edge = "rgba({},{},{},0.5)".format(*parse_color(shades["edge"]))
 
         z_pos, yc_pos = position
 
         # plot the shaft
-        z_upper = [z_pos, z_pos, z_pos + self.L, z_pos + self.L, z_pos]
+        z_half = [z_pos, z_pos, z_pos + self.L, z_pos + self.L, z_pos]
         y_upper = [self.idl / 2, self.odl / 2, self.odr / 2, self.idr / 2, self.idl / 2]
-        z_lower = [z_pos, z_pos, z_pos + self.L, z_pos + self.L, z_pos]
-        y_lower = [
-            -self.idl / 2,
-            -self.odl / 2,
-            -self.odr / 2,
-            -self.idr / 2,
-            -self.idl / 2,
-        ]
-
-        z_pos = z_upper
-        z_pos.extend(z_lower)
-
-        y_pos = y_upper
-        y_pos.extend(y_lower)
+        y_lower = [-y for y in y_upper]
 
         if check_sld:
             customdata = [self.n, self.slenderness_ratio]
@@ -1159,24 +1150,59 @@ class ShaftElement(Element):
                 + f"Element Length: {round(customdata[5], 6)} {units}<br>"
                 + f"Material: {customdata[6]}<br>"
             )
+
+        half_values = dict(
+            x=Q_(z_half, "m").to(units).m,
+            customdata=[customdata] * len(z_half),
+            text=hovertemplate,
+            mode="lines",
+            fill="toself",
+            line=dict(width=0.7, color=mesh_edge),
+            showlegend=False,
+            name=self.tag,
+            legendgroup=legend,
+            hoveron="points+fills",
+            hoverinfo="text",
+            hovertemplate=hovertemplate,
+            hoverlabel=dict(bgcolor=shades["section"], font=dict(color="#33475C")),
+        )
+
         fig.add_trace(
             go.Scatter(
-                x=Q_(z_pos, "m").to(units).m,
-                y=Q_(np.add(y_pos, yc_pos), "m").to(units).m,
-                customdata=[customdata] * len(z_pos),
-                text=hovertemplate,
-                mode="lines",
-                opacity=0.5,
-                fill="toself",
-                fillcolor=color,
-                line=dict(width=1.5, color="black"),
-                showlegend=False,
-                name=self.tag,
-                legendgroup=legend,
-                hoveron="points+fills",
-                hoverinfo="text",
-                hovertemplate=hovertemplate,
-                hoverlabel=dict(bgcolor=color),
+                y=Q_(np.add(y_upper, yc_pos), "m").to(units).m,
+                fillcolor=shades["tint"],
+                **half_values,
+            )
+        )
+
+        # the bottom half switches between the rendered metal look and the
+        # material cross section, so it carries both styles for plot_rotor
+        fig.add_trace(
+            go.Scatter(
+                y=Q_(np.add(y_lower, yc_pos), "m").to(units).m,
+                fillcolor=shades["tint"],
+                fillpattern=dict(
+                    shape="",
+                    fgcolor=shades["edge"],
+                    bgcolor=shades["section"],
+                    size=4,
+                    solidity=0.22,
+                ),
+                meta=dict(
+                    morph=dict(
+                        render={
+                            "fillcolor": shades["tint"],
+                            "fillpattern.shape": "",
+                            "line.color": mesh_edge,
+                        },
+                        section={
+                            "fillcolor": shades["section"],
+                            "fillpattern.shape": "/",
+                            "line.color": shades["edge"],
+                        },
+                    )
+                ),
+                **half_values,
             )
         )
 

--- a/ross/tests/test_plotly_theme.py
+++ b/ross/tests/test_plotly_theme.py
@@ -1,0 +1,53 @@
+import pytest
+
+from ross.plotly_theme import DEFAULT_COLOR, color_shades, parse_color
+
+
+@pytest.mark.parametrize(
+    "color, expected",
+    [
+        ("#b22222", (178, 34, 34)),
+        ("#B22222", (178, 34, 34)),
+        ("#abc", (170, 187, 204)),
+        ("rgb(178, 34, 34)", (178, 34, 34)),
+        ("rgba(178, 34, 34, 0.3)", (178, 34, 34)),
+        ("Firebrick", (178, 34, 34)),
+        ("darkslategray", (47, 79, 79)),
+        (DEFAULT_COLOR, (82, 82, 82)),
+    ],
+)
+def test_parse_color(color, expected):
+    assert parse_color(color) == expected
+
+
+@pytest.mark.parametrize(
+    "color", ["", "not a color", "#12345", "#gggggg", "rgb(1, 2)", None, 42]
+)
+def test_parse_color_fallback(color):
+    assert parse_color(color) == parse_color(DEFAULT_COLOR)
+
+
+def test_color_shades():
+    shades = color_shades("#355d7a")
+
+    assert shades["base"] == "#355d7a"
+    assert shades["tint"] == "rgba(53,93,122,0.30)"
+    assert shades["section"] == "#90a6b6"
+    assert shades["edge"] == "#223c4f"
+    assert shades["dark"] == "#2d4f68"
+
+
+def test_color_shades_are_ordered_by_lightness():
+    def lightness(color):
+        return sum(parse_color(color))
+
+    shades = color_shades("Firebrick")
+
+    assert lightness(shades["section"]) > lightness(shades["base"])
+    assert lightness(shades["base"]) > lightness(shades["dark"])
+    assert lightness(shades["dark"]) > lightness(shades["edge"])
+
+
+def test_color_shades_of_black_and_white():
+    assert color_shades("black")["edge"] == "#000000"
+    assert color_shades("white")["section"] == "#ffffff"

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -14,6 +14,7 @@ from ross.materials import Material, steel
 from ross.point_mass import *
 from ross.probe import Probe
 from ross.rotor_assembly import *
+from ross.rotor_assembly import _shaft_envelope
 from ross.shaft_element import *
 from ross.units import Q_
 from ross.results import AmbTimeResponseResults
@@ -2459,40 +2460,132 @@ def test_save_load_json(rotor8):
     assert rotor8 == rotor8_loaded
 
 
+def disk_traces(fig, tag):
+    return [d for d in fig.data if d["name"] == tag and d["fill"] == "toself"]
+
+
 def test_plot_rotor(rotor8):
     fig = rotor8.plot_rotor()
 
-    for d in fig.data:
-        if d["name"] == "Disk 0":
-            actual_x = d["x"]
-            actual_y = d["y"]
-    expected_x = [0.5, 0.502, 0.498, 0.5]
-    expected_y = [0.025, 0.125, 0.125, 0.025]
+    upper, lower = disk_traces(fig, "Disk 0")
+    disk = rotor8.disk_elements[0]
+    heaviest = max(d.m for d in rotor8.disk_elements)
+    height = np.mean(rotor8.nodes_o_d) * (0.70 + 0.55 * disk.m / heaviest)
 
-    assert_allclose(actual_x[:4], expected_x)
-    assert_allclose(actual_y[:4], expected_y)
+    # the disk is drawn as an I section, from the shaft surface outwards
+    assert_allclose(min(upper["y"]), 0.025)
+    assert_allclose(max(upper["y"]), 0.025 + height)
+    assert_allclose(min(lower["y"]), -0.025 - height)
+    assert_allclose(max(lower["y"]), -0.025)
+
+    # width of a uniform disk with the same mass and inertias
+    assert_allclose(np.ptp(upper["x"]), 0.07, atol=1e-6)
+    assert_allclose(np.mean([min(upper["x"]), max(upper["x"])]), 0.5)
 
     # mass scale factor
     for disk in rotor8.disk_elements:
         disk.scale_factor = "mass"
 
     fig = rotor8.plot_rotor()
-    for d in fig.data:
-        if d["name"] == "Disk 0":
-            actual_x = d["x"]
-            actual_y = d["y"]
-    expected_x = [0.5, 0.5016325, 0.4983675, 0.5]
-    expected_y = [0.025, 0.106625, 0.106625, 0.025]
-    assert_allclose(actual_x[:4], expected_x)
-    assert_allclose(actual_y[:4], expected_y)
+    upper, lower = disk_traces(fig, "Disk 0")
+    scale = 0.5 + 0.5 * rotor8.disk_elements[0].m / heaviest
+    assert_allclose(max(upper["y"]), 0.025 + scale * height)
 
 
 def test_plot_rotor_without_disk(rotor1):
     fig = rotor1.plot_rotor()
-    expected_element_y = np.array(
-        [0.0, 0.025, 0.025, 0.0, 0.0, -0.0, -0.025, -0.025, -0.0, -0.0]
+    upper, lower = [d for d in fig.data if d["name"] == "Shaft Element 0"]
+
+    assert_allclose(upper["y"], [0.0, 0.025, 0.025, 0.0, 0.0])
+    assert_allclose(lower["y"], [0.0, -0.025, -0.025, 0.0, 0.0])
+    assert_allclose(upper["x"], [0.0, 0.0, 0.25, 0.25, 0.0])
+
+
+def test_plot_rotor_shaft_envelope():
+    z_grid, radius = _shaft_envelope([(0.0, 0.5, 0.1, 0.1), (0.5, 0.5, 0.2, 0.2)])
+
+    # heatmap cells are centered on the grid, so their edges are the midpoints
+    # between columns, extrapolated at both ends
+    edges = np.concatenate(
+        [
+            [z_grid[0] - (z_grid[1] - z_grid[0]) / 2],
+            (z_grid[:-1] + z_grid[1:]) / 2,
+            [z_grid[-1] + (z_grid[-1] - z_grid[-2]) / 2],
+        ]
     )
-    assert_allclose(fig.data[-1]["y"], expected_element_y)
+    for boundary in (0.0, 0.5, 1.0):
+        assert np.abs(edges - boundary).min() < 1e-9
+
+    assert_allclose(radius[0], 0.05)
+    assert_allclose(radius[-1], 0.1)
+
+    # overlapping elements are drawn with the largest radius
+    _, radius = _shaft_envelope([(0.0, 0.5, 0.1, 0.1), (0.0, 0.5, 0.3, 0.3)])
+    assert_allclose(np.nanmax(radius), 0.15)
+    assert_allclose(np.nanmin(radius), 0.15)
+
+
+def test_plot_rotor_mode_buttons(rotor8):
+    fig = rotor8.plot_rotor()
+    buttons = fig.layout.updatemenus[0].buttons
+
+    assert [button.label for button in buttons] == [
+        "Bottom: render",
+        "Bottom: section",
+    ]
+
+    for button in buttons:
+        styles, indices = button.args
+
+        # visibility belongs to the legend, restyling it would bring back
+        # traces the user has hidden
+        assert "visible" not in styles
+
+        for values in styles.values():
+            assert len(values) == len(indices)
+
+    # only traces below the center line are morphed
+    for index in buttons[0].args[1]:
+        assert min(fig.data[index]["y"]) < 0
+
+
+def test_plot_rotor_legend_groups(rotor8):
+    fig = rotor8.plot_rotor()
+
+    groups = {trace.name for trace in fig.data if trace.showlegend}
+    assert groups == {"Steel", "Disk", "Bearing"}
+
+    for group in groups:
+        traces = [trace for trace in fig.data if trace.legendgroup == group]
+        assert sum(trace.showlegend for trace in traces) == 1
+        assert len(traces) > 1
+
+
+def test_plot_rotor_hover(rotor8):
+    fig = rotor8.plot_rotor()
+    templates = {
+        trace.hovertemplate for trace in fig.data if trace.hovertemplate is not None
+    }
+
+    assert (
+        "Element Number: 0<br>"
+        "Left Outer Diameter: 0.05 m<br>"
+        "Left Inner Diameter: 0.0 m<br>"
+        "Right Outer Diameter: 0.05 m<br>"
+        "Right Inner Diameter: 0.0 m<br>"
+        "Element Length: 0.25 m<br>"
+        "Material: Steel<br>"
+    ) in templates
+
+    assert (
+        "Disk Node: 2<br>"
+        "Polar Inertia: 3.296e-01<br>"
+        "Diametral Inertia: 1.781e-01<br>"
+        "Disk mass: 32.590<br>"
+    ) in templates
+
+    assert any(template.startswith("Tag: Bearing 0<br>") for template in templates)
+    assert any("Node %{customdata[0]}" in template for template in templates)
 
 
 def test_axial_force():


### PR DESCRIPTION
## What

`plot_rotor` now draws the rotor as rendered metal instead of flat translucent
patches, and the half below the center line can be switched between that
rendered look and a material cross section with the two buttons above the plot.

- **Rendered shaft** — the outer envelope of the shaft is shaded as a cylinder
  with a masked heatmap, one for each half of every center line level.
- **Cross section mode** — the lower half morphs into a hatched cross section,
  one hatch color per material, with the bore of hollow elements left void so
  only the wall is drawn.
- **Single color per element** — every shade (wash, section fill, outlines,
  glyph fills) is derived from the color the element already exposes, so
  `Material.color`, `DiskElement.color`, `BearingElement.color` and
  `SealElement.color` control the whole appearance of that element. The
  derivation is in `ross.plotly_theme` (`parse_color`, `color_shades`).
- **New glyphs** — disks are drawn as an I section whose height follows the disk
  mass and whose width is that of a uniform disk with the same mass and
  inertias; bearings as pedestals closed by a ground bar; seals as a block with
  labyrinth teeth; point masses as a small diamond.
- **Node scale** — the row of orange node markers over the shaft was replaced by
  a numbered scale below the rotor. Hovering a node drops a dotted guide line
  across the rotor (native axis spikes, no custom JavaScript). Labels that would
  be printed over each other are dropped, but every node can still be hovered.

## Unchanged

Hover text is byte identical for shaft elements, disks, bearings and seals, and
`check_sld`, `length_units` and the `**kwargs` layout overrides behave as
before. `scale_factor` (including `scale_factor="mass"`) still works, now as a
multiplier over the mass based height.

## Notes for reviewers

- The mode buttons restyle colors and patterns only, never `visible`. Trace
  visibility belongs to the legend, and restyling it would bring back traces the
  user had hidden. There is a test for this.
- Heatmap cells are centered on their coordinates, so the axial grid is built
  with columns tight against each element boundary and the cell edges land
  exactly on it. Columns are only added inside conical spans, which keeps the
  figure around 0.1 MB for `rotor_example()` and 0.9 MB for
  `compressor_example()`.
- `_patch` is private, so no deprecation path was needed. `GearElement` and
  `CouplingElement` keep their own drawing, restyled to the same palette.
  Element classes now declare their legend entry in `_legend_group`.
- Disks of the second shaft of a `CoAxialRotor` are drawn detached from the
  shaft because `df.y_pos` holds the outer diameter rather than the radius for
  that shaft. This predates this PR and was left alone.
- The `plot_rotor` outputs stored in the documentation notebooks still show the
  previous drawing until the notebooks are executed again.

## Testing

`pytest ross` (698 passed, 2 skipped, doctests included), `ruff check` and
`ruff format` clean. New tests cover the color utilities, the envelope grid, the
mode buttons, legend grouping and the hover templates.