### PR TITLE
Rebuild the validation page's RAPPID lumped-mass demonstration with ordinary ROSS elements

### DIFF
--- a/docs/validation.ipynb
+++ b/docs/validation.ipynb
@@ -48,13 +48,21 @@
    "id": "fb1cdb53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:16:57.916155Z",
-     "iopub.status.busy": "2026-08-08T00:16:57.916085Z",
-     "iopub.status.idle": "2026-08-08T00:17:04.493563Z",
-     "shell.execute_reply": "2026-08-08T00:17:04.493236Z"
+     "iopub.execute_input": "2026-08-08T10:14:05.930924Z",
+     "iopub.status.busy": "2026-08-08T10:14:05.930839Z",
+     "iopub.status.idle": "2026-08-08T10:14:13.452908Z",
+     "shell.execute_reply": "2026-08-08T10:14:13.450301Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/raphaelts/ross/.claude/worktrees/docs-validation-page/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -251,10 +259,10 @@
    "id": "ed5cdda4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:17:04.499918Z",
-     "iopub.status.busy": "2026-08-08T00:17:04.499791Z",
-     "iopub.status.idle": "2026-08-08T00:17:04.578011Z",
-     "shell.execute_reply": "2026-08-08T00:17:04.577531Z"
+     "iopub.execute_input": "2026-08-08T10:14:13.454166Z",
+     "iopub.status.busy": "2026-08-08T10:14:13.454004Z",
+     "iopub.status.idle": "2026-08-08T10:14:13.535104Z",
+     "shell.execute_reply": "2026-08-08T10:14:13.532752Z"
     }
    },
    "outputs": [
@@ -379,9 +387,12 @@
     "reproduces RAPPID's station table, so the mass data of the two models is identical and\n",
     "only its placement in the matrix differs.\n",
     "\n",
-    "We can demonstrate that this single difference accounts for the entire deviation: keep\n",
-    "the ROSS stiffness and gyroscopic matrices and replace only the mass matrix by a\n",
-    "diagonal one built by lumping ROSS's own element data (no RAPPID values are used)."
+    "We can demonstrate that this single difference accounts for the entire deviation, using\n",
+    "nothing but ordinary ROSS elements. We rebuild the same rotor as a transfer-matrix code\n",
+    "sees it: the shaft elements get a material with near-zero density — which keeps the beam\n",
+    "stiffness but removes the distributed mass, inertia and gyroscopics — and each node gets\n",
+    "a `DiskElement` carrying the lumped station data (half of each adjacent shaft element's\n",
+    "mass and inertia, plus the real disks; no RAPPID values are used)."
    ]
   },
   {
@@ -390,10 +401,10 @@
    "id": "d2f5af61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:17:04.581949Z",
-     "iopub.status.busy": "2026-08-08T00:17:04.581844Z",
-     "iopub.status.idle": "2026-08-08T00:17:04.606074Z",
-     "shell.execute_reply": "2026-08-08T00:17:04.605456Z"
+     "iopub.execute_input": "2026-08-08T10:14:13.538790Z",
+     "iopub.status.busy": "2026-08-08T10:14:13.538662Z",
+     "iopub.status.idle": "2026-08-08T10:14:13.661673Z",
+     "shell.execute_reply": "2026-08-08T10:14:13.658463Z"
     }
    },
    "outputs": [
@@ -520,13 +531,6 @@
     }
    ],
    "source": [
-    "from scipy import linalg as la\n",
-    "\n",
-    "speed = rs.Q_(500, \"RPM\").to(\"rad/s\").m\n",
-    "K = rotor.K(speed)\n",
-    "G = rotor.G()\n",
-    "M = rotor.M()\n",
-    "\n",
     "# Lump ROSS's own element data at the nodes, as a transfer-matrix code does:\n",
     "# half of each shaft element's mass and inertia at each of its two nodes,\n",
     "# plus the disk mass and inertias at their mounting nodes\n",
@@ -556,35 +560,27 @@
     "dev = np.abs((stations - rappid_stations) / rappid_stations).max()\n",
     "print(f\"lumped ROSS element data vs RAPPID station table: max deviation = {dev:.4%}\")\n",
     "\n",
-    "# Work on the lateral DOFs [x, y, theta_x, theta_y] of each node, since\n",
-    "# RAPPID's analysis is lateral-only\n",
-    "ndof = rotor.number_dof\n",
-    "lat = np.sort(np.concatenate([[n * ndof + i for i in (0, 1, 3, 4)] for n in rotor.nodes]))\n",
-    "M_lumped = np.diag(np.concatenate([[m, m, it, it] for m, ip, it in stations]))\n",
+    "# Rebuild the rotor as a transfer-matrix code sees it: massless shaft elements\n",
+    "# (stiffness only) plus one DiskElement per node carrying the station data\n",
+    "massless = rs.Material(name=\"massless_steel\", rho=1e-30, E=211e9, G_s=81.2e9)\n",
+    "shaft = [\n",
+    "    rs.ShaftElement(n=el.n, L=el.L, idl=el.idl, odl=el.odl, material=massless)\n",
+    "    for el in rotor.shaft_elements\n",
+    "]\n",
+    "disks = [\n",
+    "    rs.DiskElement(n=n, m=m, Ip=ip, Id=it) for n, (m, ip, it) in enumerate(stations)\n",
+    "]\n",
+    "lumped_rotor = rs.Rotor(shaft, disks, rotor.bearing_elements)\n",
     "\n",
-    "\n",
-    "def damped_natural_freqs(M_mat):\n",
-    "    n = M_mat.shape[0]\n",
-    "    A = np.vstack(\n",
-    "        [\n",
-    "            np.hstack([np.zeros((n, n)), np.eye(n)]),\n",
-    "            np.hstack(\n",
-    "                [\n",
-    "                    -la.solve(M_mat, K[np.ix_(lat, lat)]),\n",
-    "                    -la.solve(M_mat, speed * G[np.ix_(lat, lat)]),\n",
-    "                ]\n",
-    "            ),\n",
-    "        ]\n",
-    "    )\n",
-    "    wn = np.unique(np.abs(la.eigvals(A).imag).round(6))\n",
-    "    return wn[wn > 1][:8] / (2 * np.pi)\n",
-    "\n",
-    "\n",
+    "# First eight lateral modes of each rotor. Both mode lists also contain the\n",
+    "# torsional mode at ~123 Hz (7th mode), which RAPPID's lateral analysis does\n",
+    "# not compute — remove it before comparing\n",
     "rappid_8_hz = np.array(\n",
     "    [14.6152, 15.3284, 43.3459, 46.9251, 105.902, 112.760, 150.907, 155.810]\n",
     ")\n",
-    "consistent_hz = damped_natural_freqs(M[np.ix_(lat, lat)])\n",
-    "lumped_hz = damped_natural_freqs(M_lumped)\n",
+    "speed = rs.Q_(500, \"RPM\")\n",
+    "consistent_hz = np.delete(rotor.run_modal(speed, num_modes=24).wn[:9], 6) / (2 * np.pi)\n",
+    "lumped_hz = np.delete(lumped_rotor.run_modal(speed, num_modes=24).wn[:9], 6) / (2 * np.pi)\n",
     "\n",
     "pd.DataFrame(\n",
     "    {\n",
@@ -602,14 +598,17 @@
    "id": "6d9b1399",
    "metadata": {},
    "source": [
-    "With the lumped mass matrix, ROSS reproduces every RAPPID mode — including the fourth\n",
-    "pair, which the consistent-mass solution places 13% higher — to better than 0.1%. The\n",
-    "two codes therefore agree on the model and its stiffness, and differ only in this\n",
-    "discretization choice. Refining the mesh makes the lumped formulation converge from\n",
-    "below to the same values as the consistent formulation (which, as noted, is already\n",
-    "converged with 6 elements), so the consistent-mass frequencies are the better answer for\n",
-    "this model at this discretization — but for the first two pairs, which is what matters\n",
-    "at operating speeds near them, the 7-station lumped model is already within 0.8%."
+    "With the lumped mass distribution, ROSS reproduces every RAPPID mode — including the\n",
+    "fourth pair, which the consistent-mass solution places 13% higher — to better than 0.1%.\n",
+    "Note that the lumped rotor also lumps the *gyroscopic* effects (the massless shaft\n",
+    "contributes none; the station `DiskElement`s contribute theirs), which is exactly what\n",
+    "the point matrices of a transfer-matrix code do. The two codes therefore agree on the\n",
+    "model and its stiffness, and differ only in this discretization choice. Refining the\n",
+    "mesh makes the lumped formulation converge from below to the same values as the\n",
+    "consistent formulation (which, as noted, is already converged with 6 elements), so the\n",
+    "consistent-mass frequencies are the better answer for this model at this discretization\n",
+    "— but for the first two pairs, which is what matters at operating speeds near them, the\n",
+    "7-station lumped model is already within 0.8%."
    ]
   },
   {
@@ -655,7 +654,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Follow-up to #1337. The RAPPID comparison in the validation page demonstrated that the lumped-vs-consistent mass discretization accounts for the entire deviation between the two codes, but did so by assembling a state-space eigenvalue problem by hand (slicing `rotor.M()`/`rotor.K()`/`rotor.G()` and calling scipy directly).

This PR replaces that machinery with an equivalent construction that stays entirely within the public ROSS API:

- shaft elements built from a material with near-zero density, so they contribute beam stiffness but no distributed mass, inertia or gyroscopics;
- one `DiskElement` per node carrying the lumped station data (half of each adjacent shaft element's mass and inertia, plus the real disks) — still derived purely from ROSS's own element data, no RAPPID values used.

This is also slightly more faithful to a transfer-matrix code: the gyroscopic effects are now lumped at the stations too, exactly as Myklestad–Prohl point matrices do (the previous version kept the consistent gyroscopic matrix).

The results are unchanged: the lumped rotor reproduces all eight RAPPID modes to within 0.1%, and the consistent-mass column is identical to the previous version of the page. The notebook was re-executed in place.