### PR TITLE
Add plot_pad_temperature_3d drawing pads colored by solid temperature

### DIFF
--- a/docs/cookbook/bearings_advanced.md
+++ b/docs/cookbook/bearings_advanced.md
@@ -138,6 +138,7 @@ Useful knobs and post-processing:
 - `num_processes`: solve the frequency table in parallel
 - `bearing.coefficients(frequency)` returns `(kxx, kxy, kyx, kyy), (cxx, cxy, cyx, cyy)` interpolated at any speed
 - Plots: `plot_pressure_2d()`, `plot_pressure_3d()`, `plot_temperature_2d()`, `plot_film_temperature_3d()`, `plot_film_thickness_2d()`; `show_results()` prints a per-speed summary table
+- `plot_pad_temperature_3d()` draws the pads as real geometry colored by the solid pad conduction field, resolved through the pad thickness (`thermal_type="full"` only)
 - `bearing.save(file)` stores the solved coefficient table (reloads as a plain `BearingElement`, no re-solve)
 
 See `docs/user_guide/tutorial_bearings_part_2.ipynb` for the full tour.

--- a/docs/release_notes/version-2.4.0.rst
+++ b/docs/release_notes/version-2.4.0.rst
@@ -113,8 +113,11 @@ Old method                                         New method
 ``plot_bearing_representation()``                  removed
 ``plot_babbitt_surface_temperature()``             removed — with ``thermal_type="full"`` the film
                                                    temperature already reflects pad conduction
-``plot_solid_pad_results(...)``                    removed
+``plot_solid_pad_results(...)``                    ``plot_pad_temperature_3d()``
 =================================================  ==========================================================
 
 ``plot_results()``, ``show_results()``, ``show_coefficients_comparison()`` and
-``show_execution_time()`` keep their names, and ``plot_film_thickness_2d()`` is new.
+``show_execution_time()`` keep their names, and ``plot_film_thickness_2d()`` and
+``plot_pad_temperature_3d()`` are new: the latter draws the pads as real geometry
+colored by the solid pad conduction field (``thermal_type="full"`` only), the
+through-pad counterpart of ``plot_film_temperature_3d()``.

--- a/ross/bearings/bearing_results.py
+++ b/ross/bearings/bearing_results.py
@@ -8,6 +8,7 @@ from prettytable import PrettyTable
 from scipy.interpolate import griddata
 
 from ross.plotly_theme import tableau_colors
+from ross.units import Q_
 
 __all__ = [
     "BearingResults",
@@ -15,6 +16,35 @@ __all__ = [
     "SqueezeFilmDamperResults",
     "FluidFilmBearingResults",
 ]
+
+
+def _structured_grid_triangles(node_grid):
+    """Triangulate a structured 2-D grid of node indices.
+
+    Each cell of the grid is split into two triangles, giving the ``i, j, k``
+    vertex arrays a ``plotly.graph_objects.Mesh3d`` needs.
+
+    Parameters
+    ----------
+    node_grid : ndarray, shape (n_rows, n_cols)
+        Node indices arranged as a structured grid.
+
+    Returns
+    -------
+    triangles : ndarray, shape (2 * (n_rows - 1) * (n_cols - 1), 3)
+        Vertex indices, three per triangle.
+    """
+    node_grid = np.asarray(node_grid)
+
+    corner_a = node_grid[:-1, :-1]
+    corner_b = node_grid[1:, :-1]
+    corner_c = node_grid[1:, 1:]
+    corner_d = node_grid[:-1, 1:]
+
+    lower = np.stack([corner_a, corner_b, corner_c], axis=-1).reshape(-1, 3)
+    upper = np.stack([corner_a, corner_c, corner_d], axis=-1).reshape(-1, 3)
+
+    return np.concatenate([lower, upper], axis=0)
 
 
 class BearingResults(ABC):
@@ -211,6 +241,42 @@ class BearingResults(ABC):
             stacklevel=2,
         )
         return self.plot_film_temperature_3d(*args, **kwargs)
+
+    def plot_pad_temperature_3d(self, freq_index=0, fig=None, **kwargs):
+        """Return a 3-D mesh of the bearing pads colored by temperature.
+
+        This is the through-pad (circumferential x radial) counterpart of
+        ``plot_film_temperature_3d``: the pad geometry is drawn at its
+        physical position and colored by the solid pad / babbitt
+        temperature, showing how much heat crosses from the film into the
+        pad.
+
+        The method is part of the common bearing plotting API, so it exists
+        on every bearing result class.  Classes whose model does not compute
+        a solid pad temperature field raise ``NotImplementedError``.
+
+        Parameters
+        ----------
+        freq_index : int, optional
+            Frequency index.  Default is 0.
+        fig : go.Figure, optional
+            Existing figure to add the trace to.
+
+        Returns
+        -------
+        fig : go.Figure
+
+        Raises
+        ------
+        NotImplementedError
+            When the bearing model does not provide a solid pad temperature
+            field.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not compute a solid pad temperature "
+            "field, so plot_pad_temperature_3d is not available.  Use "
+            "plot_film_temperature_3d() for the oil film temperature."
+        )
 
     @abstractmethod
     def plot_temperature_2d(self, freq_index=0, fig=None, **kwargs):
@@ -1095,6 +1161,14 @@ class FluidFilmBearingResults(BearingResults):
         position (m) grids, one per frequency.
     leading_edge_angles : ndarray
         Per-pad leading edge angular position, rad.
+    pad_temperature_fields : list of ndarray, optional
+        Solid pad temperature grids (K), one per frequency, shaped
+        ``(n_pads, n_circumferential, n_radial)`` with radial index 0 at
+        the babbitt surface increasing outward to the pad back.  Only
+        computed by the full (conducting-pad) thermal model.
+    pad_radial_positions : ndarray, optional
+        Radius of each pad radial station (m), shape ``(n_radial,)``,
+        matching the last axis of ``pad_temperature_fields``.
     outputs : list of dict
         The solver's named-output dict of each frequency (eccentricity,
         attitude, power loss, flows, temperatures, ...).
@@ -1130,6 +1204,8 @@ class FluidFilmBearingResults(BearingResults):
         cxy,
         cyx,
         cyy,
+        pad_temperature_fields=None,
+        pad_radial_positions=None,
         initial_time=None,
         final_time=None,
     ):
@@ -1144,6 +1220,12 @@ class FluidFilmBearingResults(BearingResults):
         self.theta_grids = theta_grids
         self.z_grids = z_grids
         self.leading_edge_angles = np.asarray(leading_edge_angles, dtype=float)
+        self.pad_temperature_fields = pad_temperature_fields
+        self.pad_radial_positions = (
+            None
+            if pad_radial_positions is None
+            else np.asarray(pad_radial_positions, dtype=float)
+        )
         self.outputs = outputs
         self.kxx = kxx
         self.kxy = kxy
@@ -1301,6 +1383,183 @@ class FluidFilmBearingResults(BearingResults):
             "K",
             **kwargs,
         )
+
+    def plot_pad_temperature_3d(
+        self,
+        freq_index=0,
+        length_units="m",
+        temperature_units="degC",
+        colorscale="Viridis",
+        show_interface=True,
+        fig=None,
+        **kwargs,
+    ):
+        """Return a 3-D mesh of the pads colored by solid pad temperature.
+
+        Each pad is drawn at its true angular position as a hexahedral mesh
+        spanning the pad thickness, from the babbitt surface (inner radius)
+        to the pad back (outer radius), and extruded over the pad axial
+        length.  The mesh is colored by the solid pad conduction field of
+        the energy equation, which is resolved over the radial pad
+        stations — so the temperature drop through the pad thickness is
+        shown continuously rather than at a few discrete layers.
+
+        This is the through-pad (circumferential x radial) counterpart of
+        ``plot_film_temperature_3d``.  The solver does not resolve the
+        solid temperature along the bearing axis, so the axial extrusion is
+        geometric and each ring carries the same temperature at both axial
+        faces.
+
+        Parameters
+        ----------
+        freq_index : int, optional
+            Frequency index.  Default is 0.
+        length_units : str, optional
+            Units for the x, y and z axes.  Default is "m".
+        temperature_units : str, optional
+            Units for the temperature color scale.  Default is "degC".
+        colorscale : str, optional
+            Plotly colorscale used for the temperature.  Default is
+            "Viridis".
+        show_interface : bool, optional
+            Outline the babbitt surface of each pad with a dashed red line.
+            Default is True.
+        fig : go.Figure, optional
+            Existing figure to add the trace to.
+        kwargs : optional
+            Additional keyword arguments passed to ``fig.update_layout``.
+
+        Returns
+        -------
+        fig : go.Figure
+
+        Raises
+        ------
+        ValueError
+            When the solid pad temperature field is not available: it is
+            only computed by the full (conducting-pad) thermal model
+            (``thermal_type="full"``).
+        """
+        if self.pad_temperature_fields is None or self.pad_radial_positions is None:
+            raise ValueError(
+                "Solid pad temperature data not available: it is only "
+                'computed by the full thermal model (thermal_type="full").  '
+                "Use plot_film_temperature_3d() for the oil film temperature."
+            )
+
+        pad_temperature = (
+            Q_(np.asarray(self.pad_temperature_fields[freq_index]), "K")
+            .to(temperature_units)
+            .m
+        )
+        radius = Q_(self.pad_radial_positions, "m").to(length_units).m
+        theta_grid = self.theta_grids[freq_index]
+        z_grid = Q_(self.z_grids[freq_index], "m").to(length_units).m
+
+        n_pads = pad_temperature.shape[0]
+        n_theta, n_radial = pad_temperature.shape[1], pad_temperature.shape[2]
+        x, y, z, temperature, triangles = [], [], [], [], []
+        interface_x, interface_y, interface_z = [], [], []
+        n_nodes = 0
+
+        for pad in range(n_pads):
+            theta = self.leading_edge_angles[pad] + theta_grid[pad, :, 0]
+            z_planes = np.array([z_grid[pad].min(), z_grid[pad].max()])
+
+            theta_mesh, radius_mesh, z_mesh = np.meshgrid(
+                theta, radius, z_planes, indexing="ij"
+            )
+            x.append((radius_mesh * np.cos(theta_mesh)).ravel())
+            y.append((radius_mesh * np.sin(theta_mesh)).ravel())
+            z.append(z_mesh.ravel())
+            temperature.append(np.repeat(pad_temperature[pad], 2))
+
+            node = n_nodes + np.arange(n_theta * n_radial * 2).reshape(
+                n_theta, n_radial, 2
+            )
+            for face in (
+                node[:, 0, :],
+                node[:, -1, :],
+                node[:, :, 0],
+                node[:, :, 1],
+                node[0, :, :],
+                node[-1, :, :],
+            ):
+                triangles.append(_structured_grid_triangles(face))
+
+            if show_interface:
+                z_mid = z_planes.mean()
+                z_edge = z_mid + 1.004 * (z_planes - z_mid)
+                loop_theta = np.concatenate([theta, theta[::-1], theta[:1]])
+                loop_z = np.concatenate(
+                    [
+                        np.full(n_theta, z_edge[0]),
+                        np.full(n_theta, z_edge[1]),
+                        [z_edge[0]],
+                    ]
+                )
+                interface_x.append(radius[0] * np.cos(loop_theta))
+                interface_y.append(radius[0] * np.sin(loop_theta))
+                interface_z.append(loop_z)
+                interface_x.append([np.nan])
+                interface_y.append([np.nan])
+                interface_z.append([np.nan])
+
+            n_nodes += n_theta * n_radial * 2
+
+        triangles = np.concatenate(triangles)
+
+        if fig is None:
+            fig = go.Figure()
+
+        fig.add_trace(
+            go.Mesh3d(
+                x=np.concatenate(x),
+                y=np.concatenate(y),
+                z=np.concatenate(z),
+                i=triangles[:, 0],
+                j=triangles[:, 1],
+                k=triangles[:, 2],
+                intensity=np.concatenate(temperature),
+                colorscale=colorscale,
+                colorbar=dict(title=dict(text=f"Temperature ({temperature_units})")),
+                flatshading=True,
+                name="Pad temperature",
+                hovertemplate=(
+                    f"x: %{{x:.4g}} {length_units}<br>"
+                    f"y: %{{y:.4g}} {length_units}<br>"
+                    f"z: %{{z:.4g}} {length_units}<br>"
+                    f"Temperature: %{{intensity:.5g}} {temperature_units}"
+                    "<extra></extra>"
+                ),
+            )
+        )
+
+        if show_interface:
+            fig.add_trace(
+                go.Scatter3d(
+                    x=np.concatenate(interface_x),
+                    y=np.concatenate(interface_y),
+                    z=np.concatenate(interface_z),
+                    mode="lines",
+                    line=dict(color="red", width=3, dash="dash"),
+                    name="Babbitt surface",
+                )
+            )
+
+        fig.update_layout(
+            title=dict(text="Solid pad temperature"),
+            scene=dict(
+                xaxis_title=f"X ({length_units})",
+                yaxis_title=f"Y ({length_units})",
+                zaxis_title=f"Z ({length_units})",
+                aspectmode="data",
+            ),
+            legend=dict(x=0.02, y=0.98, xanchor="left", yanchor="top"),
+            **kwargs,
+        )
+
+        return fig
 
     def plot_temperature_2d(self, freq_index=0, fig=None, **kwargs):
         """Return the film temperature along the axial center plane, per pad.

--- a/ross/bearings/fluid_film/driver.py
+++ b/ross/bearings/fluid_film/driver.py
@@ -1939,6 +1939,13 @@ def _assemble_field_outputs(g):
         thermal model ran), each shaped ``(total_pads, dim_x, dim_z)``,
         plus ``"leading_edge_angle"`` (rad, shape ``(total_pads,)``) to
         place each pad on the bearing circumference.
+
+        When the full (conducting-pad) thermal model ran, the dict also
+        carries the solid pad temperature: ``"pad_temperature"`` (K,
+        shape ``(total_pads, dim_x, total_e_y_pad + 1)``, radial index 0
+        at the babbitt surface increasing outward to the pad back) and
+        ``"pad_radial_position"`` (m, shape ``(total_e_y_pad + 1,)``, the
+        radius of each radial station).
     """
     total_pads = g["total_pads"]
     dim_x, dim_z = g["dim_x"], g["dim_z"]
@@ -1949,7 +1956,7 @@ def _assemble_field_outputs(g):
         flat = np.asarray(a, dtype=float)[:, : dim_x * dim_z]
         return flat.reshape(total_pads, dim_x, dim_z).copy()
 
-    return {
+    fields = {
         "theta": grid(mesh.x_rad),
         "axial_position": grid(mesh.z),
         "pressure": grid(g["nodal_pressure"]),
@@ -1957,6 +1964,20 @@ def _assemble_field_outputs(g):
         "film_temperature": grid(g["t_average"]),
         "leading_edge_angle": np.asarray(pads.leading_angle_rad, dtype=float).copy(),
     }
+
+    if g.get("thermal_type") == "full":
+        te_yp = g["total_e_y_pad"]
+        stride = te_yp + g["total_e_y_film"] + 1
+        cross = np.asarray(g["temp_full"], dtype=float)[:, : dim_x * stride]
+        cross = cross.reshape(total_pads, dim_x, stride)
+        fields["pad_temperature"] = cross[:, :, te_yp::-1].copy()
+        fields["pad_radial_position"] = (
+            g["cb"]
+            + pads.journal_radius
+            + np.linspace(0.0, pads.pad_thickness, te_yp + 1)
+        )
+
+    return fields
 
 
 def _assemble_outputs(g, hp, reduced):

--- a/ross/bearings/fluid_film_bearing.py
+++ b/ross/bearings/fluid_film_bearing.py
@@ -503,6 +503,12 @@ class FluidFilmBearing(BearingElement):
                 theta_grids=[f["theta"] for f in fields],
                 z_grids=[f["axial_position"] for f in fields],
                 leading_edge_angles=fields[0]["leading_edge_angle"],
+                pad_temperature_fields=(
+                    [f["pad_temperature"] for f in fields]
+                    if "pad_temperature" in fields[0]
+                    else None
+                ),
+                pad_radial_positions=fields[0].get("pad_radial_position"),
                 outputs=case_outputs,
                 kxx=self.kxx,
                 kxy=self.kxy,

--- a/ross/tests/test_fluid_film_bearing.py
+++ b/ross/tests/test_fluid_film_bearing.py
@@ -164,6 +164,54 @@ def test_plots(fixture_bearing):
     assert isinstance(fig, go.Figure)
 
 
+@pytest.fixture(scope="module")
+def full_thermal_bearing():
+    kwargs, outputs = bearing_kwargs_from_fixture("fixed_full_coarse")
+    return FluidFilmBearing(**kwargs), outputs
+
+
+def test_pad_temperature_fields(full_thermal_bearing):
+    bearing, _ = full_thermal_bearing
+    results = bearing._results
+    field = results.pad_temperature_fields[0]
+    radii = results.pad_radial_positions
+    n_pads, _, n_radial = field.shape
+    assert n_pads == bearing.n_pads
+    assert radii.shape == (n_radial,)
+    assert_allclose(radii[-1] - radii[0], float(bearing.pad_thickness), rtol=1e-12)
+    out = results.outputs[0]
+    assert_allclose(field[:, :, 0], np.asarray(out["tc"][0]), rtol=1e-12)
+    assert_allclose(field[:, :, -1], np.asarray(out["tb"][0]), rtol=1e-12)
+
+
+def test_plot_pad_temperature_3d(full_thermal_bearing):
+    bearing, _ = full_thermal_bearing
+    field = bearing._results.pad_temperature_fields[0]
+    radii = bearing._results.pad_radial_positions
+    n_pads, n_theta, n_radial = field.shape
+
+    fig = bearing.plot_pad_temperature_3d()
+    mesh = fig.data[0]
+    assert [trace.type for trace in fig.data] == ["mesh3d", "scatter3d"]
+    assert len(mesh.x) == n_pads * n_theta * n_radial * 2
+    assert_allclose(
+        [np.min(mesh.intensity), np.max(mesh.intensity)],
+        [field.min() - 273.15, field.max() - 273.15],
+        rtol=1e-12,
+    )
+    radius = np.hypot(np.asarray(mesh.x), np.asarray(mesh.y))
+    assert_allclose([radius.min(), radius.max()], [radii[0], radii[-1]], rtol=1e-12)
+
+    fig = bearing.plot_pad_temperature_3d(show_interface=False)
+    assert [trace.type for trace in fig.data] == ["mesh3d"]
+
+
+def test_plot_pad_temperature_3d_requires_full_thermal(fixture_bearing):
+    bearing, _ = fixture_bearing
+    with pytest.raises(ValueError, match="full thermal model"):
+        bearing.plot_pad_temperature_3d()
+
+
 def test_multi_speed_and_parallel():
     kwargs, _ = bearing_kwargs_from_fixture("fixed_isoviscous")
     kwargs["frequency"] = [80.0, 110.0]

--- a/ross/tests/test_plot_results.py
+++ b/ross/tests/test_plot_results.py
@@ -493,6 +493,11 @@ def test_plot_temperature_3d_deprecated_alias(thrust_pad_results):
     assert_plotly_figure(fig)
 
 
+def test_plot_pad_temperature_3d_not_available(thrust_pad_results):
+    with pytest.raises(NotImplementedError, match="solid pad temperature"):
+        thrust_pad_results.plot_pad_temperature_3d()
+
+
 def test_squeeze_film_damper_field_plots_not_available():
     bearing = SqueezeFilmDamper(
         n=0,


### PR DESCRIPTION
## Summary

Follow-up to #1332, porting the remaining feature of #1328 onto the new fluid-film engine: a 3D view of the **solid pad** temperature, complementary to `plot_film_temperature_3d`.

The full (conducting-pad) thermal model already solves the solid pad temperature as part of its energy-equation field, but only two curves of it were reported (babbitt surface `tc` and pad back `tb`). This PR exposes the whole field and draws it.

| Method | Draws | Resolves |
|---|---|---|
| `plot_film_temperature_3d` | surface of the oil film field | circumferential × **axial** |
| `plot_pad_temperature_3d` | mesh of the pad geometry, colored by temperature | circumferential × **radial** |

Neither is a superset of the other, so they keep distinct names (the naming split itself was folded into #1332).

## Changes

- The solver's field outputs gain `pad_temperature` grids, shaped `(n_pads, n_circumferential, n_radial)` with radial index 0 at the babbitt surface, plus the radial station positions. Extracted from the energy-equation solution; matches the `tc`/`tb` named outputs exactly.
- `FluidFilmBearingResults.plot_pad_temperature_3d` draws each pad as real geometry at its true angular position, colored by the solid conduction field through the pad thickness, with unit selection and an optional dashed babbitt-surface outline.
- Improvements over the #1328 original: works **per-frequency** (the old engine stored a single field for the last solved speed) and for **any conducting-pad bearing** — fixed-geometry included, not just tilting pads.
- The solver does not resolve the solid temperature along the bearing axis, so the axial extrusion is geometric — both axial faces carry the same field. Stated in the docstring, since it is easy to misread from the plot.
- Bearings run without the full thermal model raise a `ValueError` pointing at `thermal_type`; result classes with no solid pad model share a `NotImplementedError` base implementation, keeping the plotting API uniform.
- Tutorial: the plot added to the full-thermal section of `tutorial_bearings_part_2` (notebook re-executed, no errors); the 2.4.0 migration table now maps the retired `plot_solid_pad_results` to the new method.

## Verification

- Extracted field equals the solver's `tc` (babbitt) and `tb` (back) outputs exactly, confirming the radial orientation.
- Mesh node count exact (`n_pads × n_theta × n_radial × 2`); intensity range equals the field range exactly; radial span equals `pad_thickness` exactly; `mm` and `degF` conversions exact.
- 4 new tests; the full bearing sweep passes (85 passed) along with ruff and doctests.