### PR TITLE
Make plot_rotor responsive to container width

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3350,9 +3350,12 @@ class Rotor(object):
             fig, nodes, length_units, y_low - 0.11 * y_span, x_range[0]
         )
 
-        width = 1150
+        # the figure width is left unset so it adapts to the container; the
+        # height is sized for a nominal width and the scaleanchor constraint
+        # on the y axis keeps the drawing at a 1:1 aspect ratio at any width
+        nominal_width = 800
         margin = dict(l=70, r=25, t=95, b=52)
-        pixels_per_unit = (width - margin["l"] - margin["r"]) / (
+        pixels_per_unit = (nominal_width - margin["l"] - margin["r"]) / (
             x_range[1] - x_range[0]
         )
         height = (y_range[1] - y_range[0]) * pixels_per_unit
@@ -3385,10 +3388,12 @@ class Rotor(object):
             title_text=f"Shaft radius ({length_units})",
             range=y_range,
             showgrid=False,
+            scaleanchor="x",
+            scaleratio=1,
+            constrain="domain",
             **axes,
         )
         fig.update_layout(
-            width=width,
             height=height,
             margin=margin,
             legend=dict(


### PR DESCRIPTION
## Problem

Since the `plot_rotor` redesign (19e14b06), figures were created with a hardcoded `width=1150`, so they overflowed any container narrower than that — most visibly the documentation pages, where the plot was clipped at the right edge.

| Before | After |
|--------|-------|
| Fixed 1150 px width, clipped in the docs | Autosizes to the container |

## Solution

- Leave `layout.width` unset so the figure adapts to its container, as it did before the redesign.
- Preserve the redesign's true 1:1 aspect ratio (equal pixels-per-meter in x and y) with `yaxis.scaleanchor="x"`, `scaleratio=1` and `constrain="domain"`, which holds at any container width: narrower containers shrink the y domain, wider ones just add a little axial padding.
- The figure height is still computed from the drawing's aspect ratio, now sized for a nominal 800 px width (typical docs/notebook column) and clamped to [300, 900] as before.

Passing `width=...` as a kwarg still overrides the default.

## Verification

- Rendered `rotor_example()` and `compressor_example()` at 700 px and 1400 px — both fit the container with correct proportions, node scale and legend intact.
- All `plot`-related tests in `test_rotor_assembly.py` pass; ruff check/format clean.