### PR TITLE
Use eigh in Orbit to fix numba compilation with numpy 2.5

### DIFF
--- a/ross/results.py
+++ b/ross/results.py
@@ -388,7 +388,9 @@ def _init_orbit(ru_e, rv_e):
     # fmt: on
     H = T @ T.T
 
-    lam, vecs = la.eig(H)
+    # H is symmetric, so eigh is used: eig returns complex arrays with
+    # numpy >= 2.5, which numba cannot compare or argmax
+    lam, vecs = la.eigh(H)
     # lam is the eigenvalue -> sqrt(lam) is the minor/major axis.
     # kappa encodes the relation between the axis and the precession.
     minor = np.sqrt(max(np.real(lam.min()), 0.0))
@@ -419,6 +421,10 @@ def _init_orbit(ru_e, rv_e):
     v = vecs[:, major_index]
     v = np.real(v)
     v = v / la.norm(v)
+    # the eigenvector sign is arbitrary, so it is flipped if needed to
+    # keep the major axis angle in the upper half plane [0, pi)
+    if v[1] < 0 or (v[1] == 0 and v[0] < 0):
+        v = -v
 
     major_x = major * v[0]
     major_y = major * v[1]


### PR DESCRIPTION
## Problem

CI started failing on the Python 3.12 jobs (all OSes) with a numba `TypingError` in `Orbit._init_orbit` (`ross/results.py`):

```
No implementation of function Function(<function argmax ...>) found for signature:
 >>> argmax(array(complex128, 1d, C))
```

The last green run on main (Aug 11) resolved **numba 0.66.0 + numpy 2.4.6**; the first red run (Aug 12) resolved **numba 0.67.0 + numpy 2.5.2**, released in between. numpy 2.5 changed `np.linalg.eig` to always return complex arrays (previously it downcast to real when all imaginary parts were zero), and numba 0.67 follows that typing — so `lam` is now `complex128` and `np.argmax(lam)` no longer compiles, since numba has no ordering for complex values. Only the 3.12 jobs picked up the new versions, which is why 3.10/3.11 still passed.

## Solution

`H = T @ T.T` is symmetric positive semi-definite, so `np.linalg.eigh` is the appropriate routine: it returns real eigenvalues and eigenvectors on every numpy version and is supported by numba.

Because LAPACK eigenvector signs are arbitrary (`eigh` flipped some relative to `eig`, which broke `test_deflected_shape`), the major axis eigenvector is now explicitly normalized so the major axis angle lies in the upper half plane `[0, pi)`, making the orbit output deterministic regardless of the underlying LAPACK routine.

## Verification

Reproduced the failure locally with numba 0.67.0 + numpy 2.5.2, then with the fix ran `test_rotor_assembly.py`, `test_results.py` and the `results.py` doctests on:

- numba 0.67.0 + numpy 2.5.2 (the failing CI combination): **83 passed, 1 skipped**
- numba 0.64.0 + numpy 2.4.2 (older set): all pass

ruff check/format clean.