### PR TITLE
Improve plot_rotor legend and control layout

### DIFF
--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3352,9 +3352,12 @@ class Rotor(object):
 
         # the figure width is left unset so it adapts to the container; the
         # height is sized for a nominal width and the scaleanchor constraint
-        # on the y axis keeps the drawing at a 1:1 aspect ratio at any width
+        # keeps the drawing at a 1:1 aspect ratio at any width, with both axes
+        # giving up domain rather than range so a container wider or narrower
+        # than nominal adds blank margin around the axes instead of stretching
+        # them beyond the rotor
         nominal_width = 800
-        margin = dict(l=70, r=25, t=95, b=52)
+        margin = dict(l=70, r=25, t=100, b=70)
         pixels_per_unit = (nominal_width - margin["l"] - margin["r"]) / (
             x_range[1] - x_range[0]
         )
@@ -3374,6 +3377,8 @@ class Rotor(object):
         fig.update_xaxes(
             title_text=f"Axial location ({length_units})",
             range=x_range,
+            constrain="domain",
+            constraintoward="center",
             showgrid=True,
             gridcolor="#EDF1F5",
             showspikes=True,
@@ -3393,20 +3398,34 @@ class Rotor(object):
             constrain="domain",
             **axes,
         )
+        # the title is pinned to the top of the figure and the legend hangs
+        # from a fixed line below it, so when a narrow container wraps the
+        # legend the extra rows grow downward towards the plot area instead
+        # of upward over the title
+        plot_area_height = height - margin["t"] - margin["b"]
         fig.update_layout(
             height=height,
             margin=margin,
             legend=dict(
                 orientation="h",
-                yanchor="bottom",
-                y=1.02,
-                x=0,
+                yanchor="top",
+                y=1 + (margin["t"] - 40) / plot_area_height,
+                x=0.5,
+                xanchor="center",
                 itemsizing="constant",
             ),
-            updatemenus=self._plot_mode_buttons(fig),
+            updatemenus=self._plot_mode_buttons(fig, y=-30 / plot_area_height),
         )
 
-        kwargs["title"] = kwargs.get("title", "Rotor Model")
+        title = kwargs.get("title", "Rotor Model")
+        if isinstance(title, str):
+            title = {"text": title}
+        kwargs["title"] = {
+            "yref": "container",
+            "y": 1 - 8 / height,
+            "yanchor": "top",
+            **title,
+        }
         fig.update_layout(**kwargs)
 
         return fig
@@ -3678,18 +3697,22 @@ class Rotor(object):
         )
 
     @staticmethod
-    def _plot_mode_buttons(fig):
-        """Build the buttons which switch the look of the lower half.
+    def _plot_mode_buttons(fig, y):
+        """Build the button which toggles the look of the lower half.
 
         Traces which can be drawn in more than one style carry the style values
-        for each mode in their `meta` attribute. The buttons restyle only these
-        style properties, never the trace visibility, which belongs to the
-        legend.
+        for each mode in their `meta` attribute. A single toggle button switches
+        the lower half between the render and the cross section view, restyling
+        only these style properties, never the trace visibility, which belongs
+        to the legend.
 
         Parameters
         ----------
         fig : plotly.graph_objects.Figure
             The figure object with the rotor representation.
+        y : float
+            Vertical position of the button in paper coordinates, negative to
+            place it inside the bottom margin.
 
         Returns
         -------
@@ -3724,9 +3747,10 @@ class Rotor(object):
                 direction="right",
                 x=1.0,
                 xanchor="right",
-                y=1.02,
-                yanchor="bottom",
+                y=y,
+                yanchor="top",
                 pad=dict(t=2, b=2),
+                active=-1,
                 showactive=True,
                 font=dict(size=11),
                 bgcolor="#FFFFFF",
@@ -3734,12 +3758,10 @@ class Rotor(object):
                 borderwidth=1,
                 buttons=[
                     dict(
-                        label="Bottom: render", method="restyle", args=styles("render")
-                    ),
-                    dict(
                         label="Bottom: section",
                         method="restyle",
                         args=styles("section"),
+                        args2=styles("render"),
                     ),
                 ],
             )

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -2586,16 +2586,15 @@ def test_plot_rotor_shaft_envelope():
 
 def test_plot_rotor_mode_buttons(rotor8):
     fig = rotor8.plot_rotor()
-    buttons = fig.layout.updatemenus[0].buttons
+    menu = fig.layout.updatemenus[0]
 
-    assert [button.label for button in buttons] == [
-        "Bottom: render",
-        "Bottom: section",
-    ]
+    # the button sits below the plot so it never collides with the legend
+    assert menu.y < 0
 
-    for button in buttons:
-        styles, indices = button.args
+    (button,) = menu.buttons
+    assert button.label == "Bottom: section"
 
+    for styles, indices in (button.args, button.args2):
         # visibility belongs to the legend, restyling it would bring back
         # traces the user has hidden
         assert "visible" not in styles
@@ -2604,7 +2603,7 @@ def test_plot_rotor_mode_buttons(rotor8):
             assert len(values) == len(indices)
 
     # only traces below the center line are morphed
-    for index in buttons[0].args[1]:
+    for index in button.args[1]:
         assert min(fig.data[index]["y"]) < 0
 
 


### PR DESCRIPTION
## Summary

Follow-up to #1341 fixing three layout issues in `plot_rotor` that show up with multi-material rotors and containers wider or narrower than the nominal 800px width.

- **Legend colliding with the mode buttons**: rotors with several shaft materials add legend entries that ran underneath the "Bottom: render" / "Bottom: section" buttons sharing the same row. The two buttons are now a single toggle button (plotly updatemenu `args2`) labeled "Bottom: section" — click to show the cross section, click again to restore the render — placed below the plot at the bottom right, leaving the full top row to the legend.
- **Empty axes left/right of the rotor in wide containers**: the 1:1 aspect constraint was satisfied by expanding the x range, stretching empty axes on both sides. The x axis now uses `constrain="domain"` (matching the y axis), so the axes end at the rotor and extra width becomes blank margin with the plot centered. The legend is centered to match.
- **Legend wrapping over the title in narrow containers**: the legend was anchored by its bottom edge, so wrapped rows grew upward into the title. The title is now pinned to the top of the figure and the legend hangs from a fixed line below it, so extra rows wrap downward towards the plot instead. A string `title` passed through kwargs is merged with this positioning rather than replacing it, and a dict `title` can still override the placement.

## Test plan

- `pytest ross/tests/test_rotor_assembly.py -k plot_rotor` (updated `test_plot_rotor_mode_buttons` covers the single toggle: button below the plot, `args`/`args2` restyle checks, no visibility restyling)
- Visual checks of `compressor_example().plot_rotor()` rendered at 400, 500, 800 and 1327px widths: no legend/button or legend/title overlap, axes hug the rotor at all widths, 1:1 aspect preserved