### PR TITLE
Use loky executors for coefficient solver pools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numba
 ccp-performance
 prettytable
 control
+loky>=3.0

--- a/ross/bearings/fluid_film_bearing.py
+++ b/ross/bearings/fluid_film_bearing.py
@@ -13,10 +13,10 @@ tilting pad, ...) subclass this and only translate their user-facing
 geometry into the per-pad arrays this class consumes.
 """
 
-import multiprocessing
 import time
 
 import numpy as np
+from loky import get_reusable_executor
 
 from ross.bearing_seal_element import BearingElement
 from ross.bearings.bearing_results import FluidFilmBearingResults
@@ -698,8 +698,13 @@ class FluidFilmBearing(BearingElement):
         """
         per_case = [self._engine_inputs(f) for f in self.frequency_range]
         if num_processes is not None and num_processes > 1:
-            with multiprocessing.Pool(num_processes) as pool:
-                return pool.map(_solve_case, per_case)
+            # loky starts fresh workers (no fork, so no inherited sockets
+            # crashing Jupyter kernels) and does not re-import __main__,
+            # so scripts need no if __name__ == "__main__" guard.
+            executor = get_reusable_executor(
+                max_workers=min(num_processes, len(per_case))
+            )
+            return list(executor.map(_solve_case, per_case))
         return [_solve_case(inputs) for inputs in per_case]
 
     def coefficients(self, frequency):

--- a/ross/seals/holepattern_seal.py
+++ b/ross/seals/holepattern_seal.py
@@ -1,5 +1,5 @@
 import numpy as np
-import multiprocessing
+from loky import cpu_count, get_reusable_executor
 from ross import SealElement
 from ross.units import Q_, check_units
 from ross.seals.gas_model import extract_gas_properties
@@ -265,8 +265,13 @@ class HolePatternSeal(SealElement):
             # Use multiprocessing only when beneficial (>2 frequencies)
             # For small workloads, sequential execution avoids process spawn overhead
             if len(self.frequency) > 2:
-                with multiprocessing.Pool() as pool:
-                    results = pool.map(self.run, self.frequency)
+                # loky starts fresh workers (no fork, so no inherited sockets
+                # crashing Jupyter kernels) and does not re-import __main__,
+                # so scripts need no if __name__ == "__main__" guard.
+                executor = get_reusable_executor(
+                    max_workers=min(len(self.frequency), cpu_count())
+                )
+                results = list(executor.map(self.run, self.frequency))
             else:
                 results = [self.run(freq) for freq in self.frequency]
 

--- a/ross/seals/labyrinth_seal.py
+++ b/ross/seals/labyrinth_seal.py
@@ -3,7 +3,7 @@ import sys
 from scipy.linalg import lu_factor, lu_solve
 from numpy.linalg import cond
 from warnings import warn
-import multiprocessing
+from loky import cpu_count, get_reusable_executor
 from ross import SealElement
 from ross.units import check_units, Q_
 from ross.seals.gas_model import extract_gas_properties, IdealGas, RealGas
@@ -283,8 +283,13 @@ class LabyrinthSeal(SealElement):
             # Use multiprocessing only when beneficial (>4 frequencies)
             # For small workloads, sequential execution avoids process spawn overhead
             if len(frequency) > 4:
-                with multiprocessing.Pool() as pool:
-                    results = pool.map(self.run, frequency)
+                # loky starts fresh workers (no fork, so no inherited sockets
+                # crashing Jupyter kernels) and does not re-import __main__,
+                # so scripts need no if __name__ == "__main__" guard.
+                executor = get_reusable_executor(
+                    max_workers=min(len(frequency), cpu_count())
+                )
+                results = list(executor.map(self.run, frequency))
             else:
                 results = [self.run(freq) for freq in frequency]
 


### PR DESCRIPTION
## Summary
The fork-context `multiprocessing.Pool`s in `LabyrinthSeal`, `HolePatternSeal` and `FluidFilmBearing._solve_all` crash inside Jupyter kernels: forked workers inherit the kernel's ZMQ streams and die with `ZMQError: Socket operation on non-socket` (reproduced on pyzmq 25 and 27).

All three pools now use [loky](https://github.com/joblib/loky)'s `get_reusable_executor` (the executor behind joblib/scikit-learn), added as a dependency. Loky starts fresh spawn-based workers, so nothing is forked and no kernel sockets are inherited — and unlike the stdlib `spawn` context, its workers do **not** re-import `__main__`. A plain `multiprocessing.get_context("spawn")` pool was considered first, but an unguarded script hangs forever with it: each spawned worker re-imports the script, crashes during bootstrap, and the pool silently respawns it (~32k lines of repeated tracebacks in 20 s, never exits). With loky that failure mode does not exist.

**Behavior note:** no `if __name__ == "__main__":` guard is needed on any platform — plain scripts that construct these elements at module level keep working on Linux, Windows and macOS, and Jupyter kernels are unaffected. Worker count is capped at the number of frequency cases, and the executor is reused across calls, amortizing worker startup.

## Test plan
- labyrinth/holepattern/fluid-film element suites: 43 passed
- fluid-film solver/literature/docstrings + `ross/stochastic`: 91 passed, 3 skipped (REFPROP-gated)
- Unguarded plain script constructing `LabyrinthSeal` (5 freqs) at module level: completes normally (would hang forever with a stdlib spawn pool)
- Notebook executed through nbclient/ipykernel exercising the pooled path (LabyrinthSeal 5 freqs): completes with no ZMQError, results identical to the script run
- ruff check and format clean
