### PR TITLE
Add bearing style and coordinate axes toggles to plot_rotor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 toml>=0.10.1
 pandas>=0.23
-plotly>=4.7.0
+plotly>=5.11
 xlrd
 pint>=0.18
 methodtools

--- a/ross/bearing_seal_element.py
+++ b/ross/bearing_seal_element.py
@@ -876,13 +876,103 @@ class BearingElement(Element):
 
         return customdata, hovertemplate
 
+    def _classic_glyph(self, position):
+        """Build the classic spring/damper drawing of the bearing.
+
+        The glyph mirrors the pedestal footprint: a spring and a damper in
+        parallel between the shaft surface and the support, with a hatched
+        ground line when the bearing is not linked to another element. Points
+        are returned as single polylines with None separators so the whole
+        drawing fits the same traces as the pedestal.
+
+        Parameters
+        ----------
+        position : tuple
+            Position (z, y_low, y_upp, y_center) in which the glyph will be
+            drawn.
+
+        Returns
+        -------
+        body : tuple
+            x and y lists with the spring, damper and base lines.
+        ground : tuple
+            x and y lists with the ground line and its hatching.
+        """
+        zpos, ypos, ypos_s, yc_pos = position
+
+        icon_h = ypos_s - ypos
+        icon_w = icon_h / 2
+        coils = 6
+        step = icon_w / (coils + 1)
+        z_spring = zpos - 0.4 * icon_w
+        z_damper = zpos + 0.4 * icon_w
+        y_base = ypos + 0.25 * icon_h
+        y_top = ypos + 0.75 * icon_h
+
+        x_body = []
+        y_body = []
+        x_ground = []
+        y_ground = []
+        for sign in (1, -1):
+
+            def add(xs, ys, x_list=x_body, y_list=y_body):
+                x_list += list(xs) + [None]
+                y_list += [yc_pos + sign * y if y is not None else None for y in ys] + [
+                    None
+                ]
+
+            add(
+                [zpos, zpos, None, z_spring, z_damper],
+                [ypos, y_base, None, y_base, y_base],
+            )
+            add(
+                [z_spring, z_damper, None, zpos, zpos],
+                [y_top, y_top, None, y_top, ypos_s],
+            )
+
+            zigzag = [z_spring + (-1) ** i * step for i in range(coils)]
+            add(
+                [z_spring] + zigzag + [z_spring],
+                np.linspace(y_base, y_top, coils + 2),
+            )
+
+            cup = 1.6 * step
+            add(
+                [z_damper, z_damper, None]
+                + [z_damper - cup, z_damper - cup, z_damper + cup]
+                + [z_damper + cup, None, z_damper - cup, z_damper + cup]
+                + [None, z_damper, z_damper],
+                [y_base, y_base + 2 * step, None]
+                + [y_base + 5 * step, y_base + 2 * step, y_base + 2 * step]
+                + [y_base + 5 * step, None, y_base + 4 * step, y_base + 4 * step]
+                + [None, y_base + 4 * step, y_top],
+            )
+
+            z0 = z_spring - step
+            z1 = z_damper + step
+            add([z0, z1], [ypos_s, ypos_s], x_ground, y_ground)
+            hatches = 5
+            pitch = (z1 - z0) / hatches
+            for i in range(hatches):
+                add(
+                    [z0 + i * pitch, z0 + (i + 1) * pitch],
+                    [ypos_s, ypos_s + 1.6 * step],
+                    x_ground,
+                    y_ground,
+                )
+
+        return (x_body, y_body), (x_ground, y_ground)
+
     def _patch(self, position, fig):
         """Bearing element patch.
 
         Patch that will be used to draw the bearing element using Plotly library.
         The bearing is drawn as a pedestal reaching from the shaft surface to
         its support, closed by a ground bar when it is not linked to another
-        element.
+        element. Each trace also carries the classic spring/damper drawing in
+        its meta attribute, so the button added by `Rotor.plot_rotor` can
+        restyle the same traces between the two representations without
+        touching their visibility, which belongs to the legend.
 
         Parameters
         ----------
@@ -917,6 +1007,8 @@ class BearingElement(Element):
             x_ground += [zpos - 1.3 * icon_w, zpos + 1.3 * icon_w, None]
             y_ground += [y1, y1, None]
 
+        classic_body, classic_ground = self._classic_glyph(position)
+
         customdata, hovertemplate = self._hover_info()
 
         fig.add_trace(
@@ -931,6 +1023,22 @@ class BearingElement(Element):
                 legendgroup=self._legend_group,
                 showlegend=False,
                 hoverinfo="skip",
+                meta={
+                    "bearing_style": {
+                        "pedestal": {
+                            "x": x_body,
+                            "y": y_body,
+                            "fill": "toself",
+                            "line.width": 1.0,
+                        },
+                        "spring_damper": {
+                            "x": classic_body[0],
+                            "y": classic_body[1],
+                            "fill": "none",
+                            "line.width": 1.4,
+                        },
+                    }
+                },
             )
         )
 
@@ -945,6 +1053,20 @@ class BearingElement(Element):
                     legendgroup=self._legend_group,
                     showlegend=False,
                     hoverinfo="skip",
+                    meta={
+                        "bearing_style": {
+                            "pedestal": {
+                                "x": x_ground,
+                                "y": y_ground,
+                                "line.width": 3.5,
+                            },
+                            "spring_damper": {
+                                "x": classic_ground[0],
+                                "y": classic_ground[1],
+                                "line.width": 1.4,
+                            },
+                        }
+                    },
                 )
             )
 

--- a/ross/rotor_assembly.py
+++ b/ross/rotor_assembly.py
@@ -3183,20 +3183,33 @@ class Rotor(object):
 
         return F
 
-    def plot_rotor(self, nodes=1, check_sld=False, length_units="m", **kwargs):
+    def plot_rotor(
+        self,
+        nodes=1,
+        check_sld=False,
+        length_units="m",
+        bearing_style="pedestal",
+        show_axes_indicator=False,
+        **kwargs,
+    ):
         """Plot a rotor object.
 
         This function will take a rotor object and plot its elements representation
         using Plotly.
 
-        The shaft is drawn as rendered metal above the center line, and two
-        buttons switch the half below it between the same rendered look and a
-        material cross section, where each material is hatched in its own color
-        and the bore of hollow elements is left void. Every shade in the plot is
-        derived from a single color per element, so setting `Material.color`,
-        `DiskElement.color` or `BearingElement.color` controls the whole
-        appearance of that element. Below the rotor there is a scale with the
-        node numbers; hovering a node drops a guide line across the rotor.
+        The shaft is drawn as rendered metal above the center line, and three
+        toggle buttons below the plot control the view: one switches the half
+        below the center line between the same rendered look and a material
+        cross section, where each material is hatched in its own color and the
+        bore of hollow elements is left void; one switches the bearings between
+        the solid pedestal and the classic spring/damper representation; and
+        one displays the rotor frame of reference, with z along the shaft, y
+        upwards, x out of the page and the positive rotation around z. Every
+        shade in the plot is derived from a single color per element, so
+        setting `Material.color`, `DiskElement.color` or `BearingElement.color`
+        controls the whole appearance of that element. Below the rotor there is
+        a scale with the node numbers; hovering a node drops a guide line
+        across the rotor.
 
         Parameters
         ----------
@@ -3211,6 +3224,14 @@ class Rotor(object):
         length_units : str, optional
             length units to length and diameter.
             Default is 'm'.
+        bearing_style : str, optional
+            Initial bearing representation, "pedestal" or "spring_damper".
+            The button below the plot switches between the two.
+            Default is "pedestal".
+        show_axes_indicator : bool, optional
+            If True, the coordinate axes indicator starts visible. The button
+            below the plot switches it at any time.
+            Default is False.
         kwargs : optional
             Additional key word arguments can be passed to change the plot layout only
             (e.g. width=1000, height=800, ...).
@@ -3227,6 +3248,11 @@ class Rotor(object):
         >>> rotor = rs.rotor_example()
         >>> figure = rotor.plot_rotor()
         """
+        if bearing_style not in ("pedestal", "spring_damper"):
+            raise ValueError(
+                f"bearing_style must be 'pedestal' or 'spring_damper', "
+                f"got {bearing_style!r}"
+            )
         SR = [
             shaft.slenderness_ratio
             for shaft in self.shaft_elements
@@ -3365,14 +3391,16 @@ class Rotor(object):
         # keeps the drawing at a 1:1 aspect ratio at any width, with both axes
         # giving up domain rather than range so a container wider or narrower
         # than nominal adds blank margin around the axes instead of stretching
-        # them beyond the rotor
+        # them beyond the rotor; the bottom margin reserves fixed bands for the
+        # axis title, the toggle buttons and the axes indicator, so showing or
+        # hiding the indicator never resizes the figure
         nominal_width = 800
-        margin = dict(l=70, r=25, t=100, b=70)
+        margin = dict(l=70, r=25, t=100, b=102)
         pixels_per_unit = (nominal_width - margin["l"] - margin["r"]) / (
             x_range[1] - x_range[0]
         )
-        height = (y_range[1] - y_range[0]) * pixels_per_unit
-        height = int(min(max(height + margin["t"] + margin["b"], 300), 900))
+        plot_area_height = (y_range[1] - y_range[0]) * pixels_per_unit
+        height = int(min(max(plot_area_height, 130), 730) + margin["t"] + margin["b"])
 
         axes = dict(
             zeroline=False,
@@ -3424,7 +3452,6 @@ class Rotor(object):
                 xanchor="center",
                 itemsizing="constant",
             ),
-            updatemenus=self._plot_mode_buttons(fig, y=-30 / plot_area_height),
         )
 
         title = kwargs.get("title", "Rotor Model")
@@ -3437,6 +3464,12 @@ class Rotor(object):
             **title,
         }
         fig.update_layout(**kwargs)
+
+        fig.update_layout(
+            updatemenus=self._plot_buttons(
+                fig, -60 / plot_area_height, bearing_style, show_axes_indicator
+            )
+        )
 
         return fig
 
@@ -3707,37 +3740,42 @@ class Rotor(object):
         )
 
     @staticmethod
-    def _plot_mode_buttons(fig, y):
-        """Build the button which toggles the look of the lower half.
+    def _restyle_toggle_button(fig, meta_key, label, mode_on, mode_off):
+        """Build a toggle button restyling the traces which carry `meta_key`.
 
         Traces which can be drawn in more than one style carry the style values
-        for each mode in their `meta` attribute. A single toggle button switches
-        the lower half between the render and the cross section view, restyling
-        only these style properties, never the trace visibility, which belongs
-        to the legend.
+        for each mode in their `meta` attribute, under one key per toggle. The
+        button switches these traces between the two modes, restyling only the
+        stored properties, never the trace visibility, which belongs to the
+        legend.
 
         Parameters
         ----------
         fig : plotly.graph_objects.Figure
             The figure object with the rotor representation.
-        y : float
-            Vertical position of the button in paper coordinates, negative to
-            place it inside the bottom margin.
+        meta_key : str
+            Key under which the traces store their modes.
+        label : str
+            Button label.
+        mode_on : str
+            Mode applied when the button becomes active.
+        mode_off : str
+            Mode applied when the button is released.
 
         Returns
         -------
-        updatemenus : list
-            List with the plotly updatemenus, empty if no trace can be morphed.
+        button : dict or None
+            The plotly button, or None if no trace carries `meta_key`.
         """
         morphs = [
-            (i, trace.meta["morph"])
+            (i, trace.meta[meta_key])
             for i, trace in enumerate(fig.data)
-            if isinstance(trace.meta, dict) and "morph" in trace.meta
+            if isinstance(trace.meta, dict) and meta_key in trace.meta
         ]
         if not morphs:
-            return []
+            return None
 
-        properties = sorted({key for _, morph in morphs for key in morph["render"]})
+        properties = sorted({key for _, morph in morphs for key in morph[mode_on]})
 
         def styles(mode):
             args = {}
@@ -3751,31 +3789,222 @@ class Rotor(object):
                 args[prop] = values
             return [args, [i for i, _ in morphs]]
 
-        return [
-            dict(
-                type="buttons",
-                direction="right",
-                x=1.0,
-                xanchor="right",
-                y=y,
-                yanchor="top",
-                pad=dict(t=2, b=2),
-                active=-1,
-                showactive=True,
-                font=dict(size=11),
-                bgcolor="#FFFFFF",
-                bordercolor="#C4CDD6",
-                borderwidth=1,
-                buttons=[
-                    dict(
-                        label="Bottom: section",
-                        method="restyle",
-                        args=styles("section"),
-                        args2=styles("render"),
-                    ),
-                ],
-            )
+        return dict(
+            label=label,
+            method="restyle",
+            args=styles(mode_on),
+            args2=styles(mode_off),
+        )
+
+    def _plot_buttons(self, fig, y, bearing_style, show_axes_indicator):
+        """Assemble the toggle buttons placed below the plot, on the right.
+
+        Each toggle is its own updatemenu so every button keeps an independent
+        active state. All menus share the same right edge anchor and are
+        shifted apart by pixel padding, so the row keeps its spacing at any
+        container width. The requested initial states are applied to the
+        figure here, so that the buttons and the drawing always agree.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object with the rotor representation.
+        y : float
+            Vertical position of the row in paper coordinates, negative to
+            place it inside the bottom margin.
+        bearing_style : str
+            Initial bearing representation, "pedestal" or "spring_damper".
+        show_axes_indicator : bool
+            If True, the coordinate axes indicator starts visible.
+
+        Returns
+        -------
+        updatemenus : list
+            List with one plotly updatemenu per available toggle.
+        """
+        show, hide = self._plot_axes_indicator(fig)
+        if show_axes_indicator:
+            fig.plotly_relayout(dict(show))
+
+        classic = bearing_style == "spring_damper"
+        bearings = self._restyle_toggle_button(
+            fig, "bearing_style", "Bearings: classic", "spring_damper", "pedestal"
+        )
+        if bearings and classic:
+            fig.plotly_restyle(*bearings["args"])
+
+        toggles = [
+            (
+                dict(label="Show axes", method="relayout", args=[show], args2=[hide]),
+                show_axes_indicator,
+            ),
+            (bearings, classic),
+            (
+                self._restyle_toggle_button(
+                    fig, "morph", "Bottom: section", "section", "render"
+                ),
+                False,
+            ),
         ]
+
+        updatemenus = []
+        pad_r = 0
+        for button, active in reversed(toggles):
+            if button is None:
+                continue
+            updatemenus.append(
+                dict(
+                    type="buttons",
+                    direction="right",
+                    x=1.0,
+                    xanchor="right",
+                    y=y,
+                    yanchor="top",
+                    pad=dict(t=2, b=2, r=pad_r),
+                    active=0 if active else -1,
+                    showactive=True,
+                    font=dict(size=11),
+                    bgcolor="#FFFFFF",
+                    bordercolor="#C4CDD6",
+                    borderwidth=1,
+                    buttons=[button],
+                )
+            )
+            pad_r += 28 + round(6.2 * len(button["label"]))
+
+        return updatemenus[::-1]
+
+    @staticmethod
+    def _plot_axes_indicator(fig):
+        """Draw the coordinate reference triad inside the bottom margin.
+
+        The triad shows the rotor frame of reference: z along the shaft, y
+        upwards, x out of the page and the positive rotation around z. It is
+        built only from paper-referenced, pixel-sized shapes and annotations,
+        so it keeps its size and position at any figure size and never affects
+        the axes ranges. Everything starts hidden; the button which displays
+        it only flips the visible flag of these items, leaving the layout
+        untouched.
+
+        Parameters
+        ----------
+        fig : plotly.graph_objects.Figure
+            The figure object which shapes and annotations are added on.
+
+        Returns
+        -------
+        show : dict
+            Relayout arguments which display the indicator.
+        hide : dict
+            Relayout arguments which hide it again.
+        """
+        ink = "#33475C"
+        ox, oy = 50.0, -83.0
+        arm = 38.0
+        cx = ox + 22.0
+        rx, ry = 3.2, 9.5
+        theta = np.linspace(-0.2 * np.pi, 1.2 * np.pi, 5)
+
+        first_shape = len(fig.layout.shapes or ())
+        first_annotation = len(fig.layout.annotations or ())
+
+        shape = dict(
+            xref="paper",
+            yref="paper",
+            xanchor=0,
+            yanchor=0,
+            xsizemode="pixel",
+            ysizemode="pixel",
+            fillcolor="rgba(0,0,0,0)",
+            visible=False,
+        )
+        # the x axis points out of the page, drawn as a circle with a center
+        # dot; the rotation around z is an open elliptic arc around the z arm,
+        # built from cubic Bezier segments since shape paths take no arcs
+        fig.add_shape(
+            type="circle",
+            x0=ox - 6.5,
+            y0=oy - 6.5,
+            x1=ox + 6.5,
+            y1=oy + 6.5,
+            line=dict(color=ink, width=1.6),
+            **shape,
+        )
+
+        def point(t):
+            return np.array([cx + rx * np.cos(t), oy + ry * np.sin(t)])
+
+        def slope(t):
+            return np.array([-rx * np.sin(t), ry * np.cos(t)])
+
+        arc = "M {:.2f},{:.2f}".format(*point(theta[0]))
+        for t0, t1 in zip(theta[:-1], theta[1:]):
+            handle = (4 / 3) * np.tan((t1 - t0) / 4)
+            arc += " C {:.2f},{:.2f} {:.2f},{:.2f} {:.2f},{:.2f}".format(
+                point(t0)[0] + handle * slope(t0)[0],
+                point(t0)[1] + handle * slope(t0)[1],
+                point(t1)[0] - handle * slope(t1)[0],
+                point(t1)[1] - handle * slope(t1)[1],
+                *point(t1),
+            )
+        fig.add_shape(type="path", path=arc, line=dict(color=ink, width=1.3), **shape)
+
+        shape["fillcolor"] = ink
+        fig.add_shape(
+            type="circle",
+            x0=ox - 2,
+            y0=oy - 2,
+            x1=ox + 2,
+            y1=oy + 2,
+            line=dict(width=0),
+            **shape,
+        )
+
+        # arrowhead at the open end of the arc, drawn as a filled triangle
+        # aligned with the direction of travel; annotation arrows misplace
+        # their head when the tail is this short
+        tip = point(theta[-1])
+        tangent = slope(theta[-1])
+        tangent /= np.hypot(*tangent)
+        normal = np.array([-tangent[1], tangent[0]])
+        apex = tip + 6.5 * tangent
+        corners = (tip - 2.5 * tangent + 4 * normal, tip - 2.5 * tangent - 4 * normal)
+        fig.add_shape(
+            type="path",
+            path="M {:.2f},{:.2f} L {:.2f},{:.2f} L {:.2f},{:.2f} Z".format(
+                *apex, *corners[0], *corners[1]
+            ),
+            line=dict(width=0),
+            **shape,
+        )
+
+        base = dict(x=0, y=0, xref="paper", yref="paper", visible=False)
+        arrow = dict(
+            text="",
+            showarrow=True,
+            arrowhead=2,
+            arrowsize=1.2,
+            arrowwidth=1.6,
+            arrowcolor=ink,
+            **base,
+        )
+        fig.add_annotation(xshift=ox + arm, yshift=oy, ax=-(arm - 8), ay=0, **arrow)
+        fig.add_annotation(xshift=ox, yshift=oy + arm, ax=0, ay=arm - 8, **arrow)
+
+        label = dict(showarrow=False, font=dict(size=12, color=ink), **base)
+        fig.add_annotation(xshift=ox + arm + 10, yshift=oy, text="<i>z</i>", **label)
+        fig.add_annotation(xshift=ox, yshift=oy + arm + 10, text="<i>y</i>", **label)
+        fig.add_annotation(xshift=ox - 17, yshift=oy - 12, text="<i>x</i>", **label)
+        fig.add_annotation(xshift=cx + 1, yshift=oy + 17, text="<i>ω</i>", **label)
+
+        show = {}
+        for i in range(first_shape, len(fig.layout.shapes)):
+            show[f"shapes[{i}].visible"] = True
+        for i in range(first_annotation, len(fig.layout.annotations)):
+            show[f"annotations[{i}].visible"] = True
+        hide = dict.fromkeys(show, False)
+
+        return show, hide
 
     @check_units
     def run_campbell(

--- a/ross/tests/test_rotor_assembly.py
+++ b/ross/tests/test_rotor_assembly.py
@@ -2584,15 +2584,25 @@ def test_plot_rotor_shaft_envelope():
     assert_allclose(np.nanmin(radius), 0.15)
 
 
+def toggle_button(fig, label):
+    for menu in fig.layout.updatemenus:
+        if menu.buttons[0].label == label:
+            return menu.buttons[0]
+    raise AssertionError(f"no button labelled {label!r}")
+
+
 def test_plot_rotor_mode_buttons(rotor8):
     fig = rotor8.plot_rotor()
-    menu = fig.layout.updatemenus[0]
 
-    # the button sits below the plot so it never collides with the legend
-    assert menu.y < 0
+    labels = [menu.buttons[0].label for menu in fig.layout.updatemenus]
+    assert labels == ["Show axes", "Bearings: classic", "Bottom: section"]
 
-    (button,) = menu.buttons
-    assert button.label == "Bottom: section"
+    for menu in fig.layout.updatemenus:
+        # the buttons sit below the plot so they never collide with the legend
+        assert menu.y < 0
+        assert len(menu.buttons) == 1
+
+    button = toggle_button(fig, "Bottom: section")
 
     for styles, indices in (button.args, button.args2):
         # visibility belongs to the legend, restyling it would bring back
@@ -2605,6 +2615,75 @@ def test_plot_rotor_mode_buttons(rotor8):
     # only traces below the center line are morphed
     for index in button.args[1]:
         assert min(fig.data[index]["y"]) < 0
+
+
+def test_plot_rotor_bearing_style_button(rotor8):
+    fig = rotor8.plot_rotor()
+    button = toggle_button(fig, "Bearings: classic")
+
+    for styles, indices in (button.args, button.args2):
+        assert "visible" not in styles
+        for values in styles.values():
+            assert len(values) == len(indices)
+
+    # the classic drawing is bare lines, the pedestal is refilled on the
+    # way back, and both reach the same support
+    classic, indices = button.args
+    pedestal, _ = button.args2
+    assert {fill for fill in classic["fill"] if fill is not None} == {"none"}
+    assert {fill for fill in pedestal["fill"] if fill is not None} == {"toself"}
+    for fill, index, y_classic in zip(classic["fill"], indices, classic["y"]):
+        if fill is None:
+            continue
+        drawn = [y for y in fig.data[index]["y"] if y is not None]
+        assert_allclose(max(y for y in y_classic if y is not None), max(drawn))
+        assert_allclose(min(y for y in y_classic if y is not None), min(drawn))
+
+    # the initial representation can be the classic one, with its button
+    # already active
+    fig = rotor8.plot_rotor(bearing_style="spring_damper")
+    button = toggle_button(fig, "Bearings: classic")
+    (menu,) = [m for m in fig.layout.updatemenus if m.buttons[0] == button]
+    assert menu.active == 0
+    for index, x_classic in zip(button.args[1], button.args[0]["x"]):
+        assert_allclose(
+            [x for x in fig.data[index]["x"] if x is not None],
+            [x for x in x_classic if x is not None],
+        )
+
+    with pytest.raises(ValueError):
+        rotor8.plot_rotor(bearing_style="springs")
+
+
+def test_plot_rotor_axes_indicator(rotor8):
+    fig = rotor8.plot_rotor()
+
+    # the indicator starts hidden and is pixel sized, leaving the data
+    # ranges and the figure size alone
+    assert len(fig.layout.shapes) > 0
+    assert all(shape.visible is False for shape in fig.layout.shapes)
+    assert all(shape.xsizemode == "pixel" for shape in fig.layout.shapes)
+
+    button = toggle_button(fig, "Show axes")
+    height = fig.layout.height
+    y_range = fig.layout.yaxis.range
+
+    fig.plotly_relayout(dict(button.args[0]))
+    assert all(shape.visible for shape in fig.layout.shapes)
+    assert any(annotation.visible for annotation in fig.layout.annotations)
+
+    # showing the indicator never resizes the figure nor moves the legend
+    assert fig.layout.height == height
+    assert fig.layout.yaxis.range == y_range
+
+    fig.plotly_relayout(dict(button.args2[0]))
+    assert all(shape.visible is False for shape in fig.layout.shapes)
+
+    fig = rotor8.plot_rotor(show_axes_indicator=True)
+    assert all(shape.visible for shape in fig.layout.shapes)
+    assert fig.layout.height == height
+    (menu,) = [m for m in fig.layout.updatemenus if m.buttons[0].label == "Show axes"]
+    assert menu.active == 0
 
 
 def test_plot_rotor_legend_groups(rotor8):


### PR DESCRIPTION
## Summary

Adds two view toggles to `plot_rotor`, next to the existing cross section button, so the plot now has three independent buttons at the bottom right:

- **Bearings: classic** — switches every bearing between the solid pedestal and the classic spring/damper drawing (closes #1352). Also available as an initial-state argument, `plot_rotor(bearing_style="spring_damper")`, e.g. for static image export. Works for grounded bearings and for bearings linked to other elements (`n_link`), and leaves seals untouched.
- **Show axes** — displays the rotor frame of reference at the bottom left: z along the shaft, y upwards, x out of the page (circled dot) and the positive rotation around z as an open arc with an arrowhead. Also available as `plot_rotor(show_axes_indicator=True)`. This supersedes the indicator proposed in #1324.

## Design notes

- The bearing toggle reuses the `meta` morph mechanism of the cross section button: each bearing trace carries both drawings in its `meta` attribute and the button only restyles geometry/style properties, never trace visibility, so legend clicks keep working in either representation.
- The axes indicator is built exclusively from paper-referenced, **pixel-sized** shapes and annotations placed in a reserved band of the bottom margin. Its button only flips `visible` flags, so toggling it never changes the axes ranges, the figure height or the legend position, and the triad has the same size for every rotor. The rotation arc is built from cubic Bezier segments (shape paths take no SVG arc commands) and its arrowhead is a filled triangle path aligned with the arc tangent (annotation arrows misplace their head on short tails).
- Each toggle is its own `updatemenus` entry so the buttons keep independent active states; they share the right-edge anchor and are spaced by pixel padding, keeping the row intact at any container width.

## Behavior changes

- The bottom margin grows from 70 to 102 px and the button row moves below the "Axial location" title (three buttons would collide with the centered title on narrow containers). Every rotor figure is therefore ~32 px taller than before.
- `requirements.txt` now declares `plotly>=5.11`. The previous `>=4.7.0` floor was already stale: `plot_rotor` relies on scatter `fillpattern` (plotly 5.7) for the cross section hatching, so older versions fail at plot time. plotly 5.11 installs on every Python version ROSS supports (>=3.9).

## Tests

- Updated `test_plot_rotor_mode_buttons` for the three-button row and added `test_plot_rotor_bearing_style_button` and `test_plot_rotor_axes_indicator`, which also assert that showing the indicator does not resize the figure.
- Verified rendering for `rotor_example`, `compressor_example` and `coaxrotor_example` in every toggle combination and at multiple container widths.

Closes #1352.