### PR TITLE
Keep card icons transparent in dark mode

### DIFF
--- a/docs/_static/theme-ross.css
+++ b/docs/_static/theme-ross.css
@@ -517,6 +517,10 @@ dl.py dd {
 
 html[data-theme="dark"] .sd-card img[src*=".svg"] {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
+  /* pydata-sphinx-theme paints a white background behind content images
+     in dark mode; the invert above would render it as a gray slab, so
+     keep these transparent line-art icons on the card surface */
+  background-color: transparent;
 }
 
 /* ---------- Prev / next pager ---------- */


### PR DESCRIPTION
## Summary

Follow-up to #1356 (this commit was pushed to that branch just after it merged, so it never landed).

The landing-page card icons showed a gray box behind them in dark mode. The SVGs are transparent; pydata-sphinx-theme paints `background-color: #fff` behind every content image in dark mode, and the card-icon `invert(0.82)` filter applies to the element's background too, rendering that white box as a gray slab against the card surface. Setting `background-color: transparent` on the same selector keeps the line-art icons directly on the card.

## Test plan

Built the docs locally and verified the landing-page cards in dark mode no longer show the background box.